### PR TITLE
[PMD-821] Oracle and DB2 dialects were translating TRUE() as '1', FALSE ...

### DIFF
--- a/src/org/pentaho/pms/mql/dialect/DB2Dialect.java
+++ b/src/org/pentaho/pms/mql/dialect/DB2Dialect.java
@@ -40,13 +40,13 @@ public class DB2Dialect extends DefaultSQLDialect {
     
     supportedFunctions.put("TRUE", new DefaultSQLFunctionGenerator(SQLFunctionGeneratorInterface.PARAM_FUNCTION, "TRUE()", 0) { //$NON-NLS-1$ //$NON-NLS-2$
       public void generateFunctionSQL(FormulaTraversalInterface formula, StringBuffer sb, String locale, FormulaFunction f) throws PentahoMetadataException {
-        sb.append("1");
+        sb.append("1=1");
       }
     });
 
     supportedFunctions.put("FALSE", new DefaultSQLFunctionGenerator(SQLFunctionGeneratorInterface.PARAM_FUNCTION, "FALSE()", 0) { //$NON-NLS-1$ //$NON-NLS-2$
       public void generateFunctionSQL(FormulaTraversalInterface formula, StringBuffer sb, String locale, FormulaFunction f) throws PentahoMetadataException {
-        sb.append("0");
+        sb.append("1=0");
       }
     });
   }

--- a/src/org/pentaho/pms/mql/dialect/OracleDialect.java
+++ b/src/org/pentaho/pms/mql/dialect/OracleDialect.java
@@ -41,13 +41,13 @@ public class OracleDialect extends DefaultSQLDialect {
     
     supportedFunctions.put("TRUE", new DefaultSQLFunctionGenerator(SQLFunctionGeneratorInterface.PARAM_FUNCTION, "TRUE()", 0) { //$NON-NLS-1$ //$NON-NLS-2$
       public void generateFunctionSQL(FormulaTraversalInterface formula, StringBuffer sb, String locale, FormulaFunction f) throws PentahoMetadataException {
-        sb.append("1");
+        sb.append("1=1");
       }
     });
 
     supportedFunctions.put("FALSE", new DefaultSQLFunctionGenerator(SQLFunctionGeneratorInterface.PARAM_FUNCTION, "FALSE()", 0) { //$NON-NLS-1$ //$NON-NLS-2$
       public void generateFunctionSQL(FormulaTraversalInterface formula, StringBuffer sb, String locale, FormulaFunction f) throws PentahoMetadataException {
-        sb.append("0");
+        sb.append("1=0");
       }
     });
   }

--- a/test/org/pentaho/metadata/SqlOpenFormulaTest.java
+++ b/test/org/pentaho/metadata/SqlOpenFormulaTest.java
@@ -489,13 +489,16 @@ public class SqlOpenFormulaTest {
     
     handleFormula(getOrdersModel(), "Oracle", //$NON-NLS-1$
         "TRUE()" //$NON-NLS-1$
-        ,"1" //$NON-NLS-1$
+        ,"1=1" //$NON-NLS-1$
       );
     handleFormula(getOrdersModel(), "Oracle", //$NON-NLS-1$
         "FALSE()" //$NON-NLS-1$
-        ,"0" //$NON-NLS-1$
+        ,"1=0" //$NON-NLS-1$
       );
-
+      handleFormula(getOrdersModel(), "Oracle", //$NON-NLS-1$
+              "AND(TRUE();OR(FALSE();TRUE()))" //$NON-NLS-1$
+              ,"1=1 AND (1=0 OR 1=1)" //$NON-NLS-1$
+      );
     handleFormula(getOrdersModel(), "Hypersonic", //$NON-NLS-1$ 
         "TRUE()" //$NON-NLS-1$
         ,"TRUE" //$NON-NLS-1$
@@ -507,14 +510,17 @@ public class SqlOpenFormulaTest {
 
     handleFormula(getOrdersModel(), "DB2", //$NON-NLS-1$ 
         "TRUE()" //$NON-NLS-1$
-        ,"1" //$NON-NLS-1$
+        ,"1=1" //$NON-NLS-1$
       );
     handleFormula(getOrdersModel(), "DB2", //$NON-NLS-1$ 
         "FALSE()" //$NON-NLS-1$
-        ,"0" //$NON-NLS-1$
+        ,"1=0" //$NON-NLS-1$
       );
-
-    handleFormula(getOrdersModel(), "MSSQL", //$NON-NLS-1$ 
+    handleFormula(getOrdersModel(), "DB2", //$NON-NLS-1$
+              "AND(TRUE();OR(FALSE();TRUE()))" //$NON-NLS-1$
+              ,"1=1 AND (1=0 OR 1=1)" //$NON-NLS-1$
+      );
+    handleFormula(getOrdersModel(), "MSSQL", //$NON-NLS-1$
         "TRUE()" //$NON-NLS-1$
         ,"(1=1)" //$NON-NLS-1$
       );


### PR DESCRIPTION
...as '0', which was producing invalid SQL (e.g. "WHERE ( 1 )" ).

Modified to use 1=1, 1=0 instead, since neither database offers a better option for representing boolean.
