### PR TITLE
Fixing test failures resulting from Java 7 switch.  Failures were due to...

### DIFF
--- a/src/org/pentaho/pms/mql/dialect/SQLJoin.java
+++ b/src/org/pentaho/pms/mql/dialect/SQLJoin.java
@@ -128,14 +128,19 @@ import org.pentaho.pms.util.Const;
 			// Case: No join order / no join order
 			//
 			if (Const.isEmpty(getJoinOrderKey()) && Const.isEmpty(other.getJoinOrderKey())) {
-				
+
+                if (getJoinType() == other.getJoinType()) {
+                    // no order key and same join type
+                    return 0;
+                }
+
 				// Case: inner join : goes below
 				//
 				if (getJoinType()==INNER_JOIN) {
 					return -1;
 				}
 				// CASE: no inner join / inner join : goes to the top
-				else if (getJoinType()==INNER_JOIN) {
+				else if (other.getJoinType()==INNER_JOIN) {
 					return 1;
 				}
 				else {
@@ -150,7 +155,7 @@ import org.pentaho.pms.util.Const;
 				// Case: ? / inner join : goes to the top
 				//
 				if (getJoinType()!=INNER_JOIN) {
-					return 1; 
+					return 1;
 				}
 				else {
 					// CASE: ? / no inner join : nothing to work with:

--- a/test/org/pentaho/metadata/AdvancedQueryTest.java
+++ b/test/org/pentaho/metadata/AdvancedQueryTest.java
@@ -824,7 +824,7 @@ public class AdvancedQueryTest {
     
     MappedQuery query = new AdvancedSqlGenerator().generateSql(myTest, "en_US", null, databaseMeta);
     TestHelper.assertEqualsIgnoreWhitespaces( 
-        "SELECT DISTINCT bt1.pc1 AS COL0 ,bt2.pc2 AS COL1 ,bt3.pc3 AS COL2 FROM pt1 bt1 LEFT OUTER JOIN ( pt2 bt2 JOIN pt3 bt3 ON ( bt2.pc2 = bt3.pc3 ) ) ON ( bt1.pc1 = bt2.pc2 )",
+        "SELECT DISTINCT bt1.pc1 AS COL0,bt2.pc2 AS COL1,bt3.pc3 AS COL2 FROM pt3 bt3 JOIN(pt1 bt1 LEFT OUTER JOIN pt2 bt2 ON(bt1.pc1 = bt2.pc2))ON(bt2.pc2 = bt3.pc3)",
         query.getQuery()    
     ); //$NON-NLS-1$
   }
@@ -917,7 +917,7 @@ public class AdvancedQueryTest {
     
     MappedQuery query = new AdvancedSqlGenerator().generateSql(myTest, "en_US", null, databaseMeta);
     TestHelper.assertEqualsIgnoreWhitespaces( 
-        "SELECT DISTINCT bt1.k AS COL0 ,bt2.k AS COL1 ,bt3.k AS COL2 ,bt4.k AS COL3 FROM t1 bt1 JOIN ( t2 bt2 LEFT OUTER JOIN ( t3 bt3 JOIN t4 bt4 ON ( bt3.k = bt4.k ) ) ON ( bt2.k = bt3.k ) ) ON ( bt1.k = bt2.k )",
+        "SELECT DISTINCT bt1.k AS COL0,bt2.k AS COL1,bt3.k AS COL2,bt4.k AS COL3 FROM t1 bt1 JOIN(t4 bt4 JOIN(t2 bt2 LEFT OUTER JOIN t3 bt3 ON(bt2.k = bt3.k))ON(bt3.k = bt4.k))ON(bt1.k = bt2.k)",
         query.getQuery()    
     ); //$NON-NLS-1$
   }

--- a/test/org/pentaho/metadata/SqlGeneratorTest.java
+++ b/test/org/pentaho/metadata/SqlGeneratorTest.java
@@ -2805,7 +2805,7 @@ public class SqlGeneratorTest {
     SqlGenerator generator = new SqlGenerator();
     MappedQuery query = generator.generateSql(myTest, "en_US", null, databaseMeta);
     TestHelper.assertEqualsIgnoreWhitespaces( 
-        "SELECT DISTINCT bt1.pc1 AS COL0 ,bt2.pc2 AS COL1 ,bt3.pc3 AS COL2 FROM pt1 bt1 LEFT OUTER JOIN ( pt2 bt2 JOIN pt3 bt3 ON ( bt2.pc2 = bt3.pc3 ) ) ON ( bt1.pc1 = bt2.pc2 )",
+        "SELECT DISTINCT bt1.pc1 AS COL0,bt2.pc2 AS COL1,bt3.pc3 AS COL2 FROM pt3 bt3 JOIN(pt1 bt1 LEFT OUTER JOIN pt2 bt2 ON(bt1.pc1 = bt2.pc2))ON(bt2.pc2 = bt3.pc3)",
         query.getQuery()    
     ); //$NON-NLS-1$
   }
@@ -2903,7 +2903,7 @@ public class SqlGeneratorTest {
     SqlGenerator generator = new SqlGenerator();
     MappedQuery query = generator.generateSql(myTest, "en_US", null, databaseMeta);
     TestHelper.assertEqualsIgnoreWhitespaces( 
-        "SELECT DISTINCT bt1.k AS COL0 ,bt2.k AS COL1 ,bt3.k AS COL2 ,bt4.k AS COL3 FROM t1 bt1 JOIN ( t2 bt2 LEFT OUTER JOIN ( t3 bt3 JOIN t4 bt4 ON ( bt3.k = bt4.k ) ) ON ( bt2.k = bt3.k ) ) ON ( bt1.k = bt2.k )",
+        "SELECT DISTINCT bt1.k AS COL0,bt2.k AS COL1,bt3.k AS COL2,bt4.k AS COL3 FROM t1 bt1 JOIN(t4 bt4 JOIN(t2 bt2 LEFT OUTER JOIN t3 bt3 ON(bt2.k = bt3.k))ON(bt3.k = bt4.k))ON(bt1.k = bt2.k)",
         query.getQuery()    
     ); //$NON-NLS-1$
   }


### PR DESCRIPTION
... a bug in the SQLJoin.compareTo() implementation that only started showing up when the sequence of calls to compareTo changed.

The implementation was asymmetric in cases where neither this nor other have a defined joinOrderKey.  If two SQLJoin objects with INNER_JOIN were compared, for example, compareTo(x,y)==-1, and compareTo(y,x)==-1.
There was also a code path that allowed an innerJoin and an outerJoin to be compared as 0.  4 tests had expected results based on this incorrect comparison.

Note that there is still the possibility of tests breaking due to indeterminate ordering when .compareTo() returns 0.  It could be worth adding further checks against SqlJoin fields to better lock in a fixed ordering.
