### PR TITLE
[TEST] Fix for HiveDialectTest.testCanLoad().

### DIFF
--- a/test/org/pentaho/pms/mql/dialect/HiveDialectTest.java
+++ b/test/org/pentaho/pms/mql/dialect/HiveDialectTest.java
@@ -577,15 +577,5 @@ public class HiveDialectTest {
   public void testCanLoad() {
     // We should be able to load ourselves since we've registered the MockHiveDatabaseMeta
     assertTrue( HiveDialect.canLoad() );
-
-    // Remove the MockHiveDatabaseMeta. Without it we shouldn't be able to load HiveDialect
-    DatabaseInterface hiveMeta = DatabaseMeta.getDatabaseInterfacesMap().get( "HIVE" );
-    DatabaseMeta.getDatabaseInterfacesMap().put( "HIVE", null );
-    try {
-      assertFalse( HiveDialect.canLoad() );
-    } finally {
-      // Restore the database meta so any other tests that depend on it will work
-      DatabaseMeta.getDatabaseInterfacesMap().put( "HIVE", hiveMeta );
-    }
   }
 }


### PR DESCRIPTION
 Removing the dialect is not possible anymore since the Map was changed to unmodifiable...Checked
with Nick and Matt and they agree this is not relevant anymore...
