### PR TITLE
[BACKLOG-872] Adding toString() to keep existing calls working

### DIFF
--- a/src/org/pentaho/metadata/model/concept/Property.java
+++ b/src/org/pentaho/metadata/model/concept/Property.java
@@ -47,4 +47,12 @@ public class Property<T> implements Serializable {
   public T getValue() {
     return value;
   }
+
+  public String toString() {
+    if ( value != null ) {
+      return value.toString();
+    }
+    return null;
+  }
+
 }


### PR DESCRIPTION
@e-cuellar Simple fix to review - instaview was calling getProperty().toString() and then checking if it was equal to "OLAP".  This fix will allow any uses like that to keep working, as they will be hard to detect since they compile.
