### PR TITLE
[PIR-1135] - Regression: Drag-and-drop fields with parenthesis marks "("...

### DIFF
--- a/src/org/pentaho/metadata/messages/messages.properties
+++ b/src/org/pentaho/metadata/messages/messages.properties
@@ -108,6 +108,9 @@ XmiParser.ERROR_0008_FAILED_TO_CONVERT_PROPERTY=Failed to convert property of ty
 XmiParser.ERROR_0009_MISSING_DATABASE_PARENT=Physical Table {0} missing database parent
 XmiParser.ERROR_0010_UNABLE_TO_FIND_COL_FOR_CATEGORY=Unable to find column {0} for category {1}
 XmiParser.ERROR_0011_UNSUPPORTED_DOMAIN=Domain {0} has an unsupported database access-type likely due to the issue: http://jira.pentaho.com/browse/PDI-11252. JNDI will be used instead. Please correct this in your Metadata Domain file as documented here: http://jira.pentaho.com/browse/PIR-981
+XmiParser.ERROR_0012_INVALID_TABLE_ID=Logical table has an invalid id: {0}. It was replaced with {1}
+XmiParser.ERROR_0012_INVALID_COLUMN_ID=Logical column has an invalid id: {0}. It was replaced with {1}
+XmiParser.ERROR_0012_INVALID_CATEGORY_ID=Category has an invalid id: {0}. It was replaced with {1}
 
 MondrianModelExporter.ERROR_0001_ERROR_NO_RELATIONSHIP=Can't create model. \nThere is no relationship between tables [ {0} ] and [ {1} ]
 

--- a/src/org/pentaho/metadata/util/Util.java
+++ b/src/org/pentaho/metadata/util/Util.java
@@ -72,6 +72,46 @@ public class Util {
     return name;
   }
 
+  private static boolean isLatinLetter( char ch ) {
+    return ( ( 'a' <= ch ) && ( ch <= 'z' ) ) ||
+      ( ( 'A' <= ch ) && ( ch <= 'Z' ) );
+  }
+
+  private static boolean isAsciiDigit( char ch ) {
+    return ( '0' <= ch ) && ( ch <= '9' );
+  }
+
+  private static boolean isAcceptableNonLetter( char ch ) {
+    return ( ch == '_' || ch == '$' );
+  }
+
+  /**
+   * Returns <tt>true</tt> if <tt>code</tt> contains only latin characters, digits and '<tt>_</tt>' or '<tt>$</tt>'.
+   * <tt>null</tt> or empty string is considered to be an invalid value.
+   *
+   * @param id proposed id for column or table
+   * @return <tt>true</tt> if the proposed id is acceptable and <tt>false</tt> otherwise
+   */
+  public static boolean validateId( CharSequence id ) {
+    if ( id == null || id.length() == 0 ) {
+      return false;
+    }
+
+    for ( int i = 0, len = id.length(); i < len; i++ ) {
+      char ch = id.charAt( i );
+      if ( !isLatinLetter( ch ) && !isAsciiDigit( ch ) && !isAcceptableNonLetter( ch ) ) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  public static IllegalArgumentException idValidationFailed( String id ) {
+    return new IllegalArgumentException(
+      "Cannot set id '" + id + "'. Please use Util.toId() to create a well-formed identifier" );
+  }
+
   /**
    * Implements Oracle style NVL function
    * 

--- a/src/org/pentaho/metadata/util/XmiParser.java
+++ b/src/org/pentaho/metadata/util/XmiParser.java
@@ -1568,6 +1568,8 @@ public class XmiParser {
         }
       }
     }
+
+    validateDomain(domain);
     return domain;
   }
 
@@ -1928,6 +1930,71 @@ public class XmiParser {
     domain.setLocales( localeTypes );
 
   }
+
+  private void validateDomain( Domain domain ) {
+    for ( LogicalModel model : domain.getLogicalModels() ) {
+      validateModel( model );
+    }
+  }
+
+  private void validateModel( LogicalModel model ) {
+    Map<String, LogicalTable> tablesMapping = createIdToConceptMapping( model.getLogicalTables() );
+    for ( LogicalTable table : model.getLogicalTables() ) {
+      validateTable( table, tablesMapping );
+    }
+
+    Map<String, Category> categoiesMapping = createIdToConceptMapping( model.getCategories() );
+    for ( Category category : model.getCategories() ) {
+      validateCategory( category, categoiesMapping );
+    }
+  }
+
+  private void validateTable( LogicalTable table, Map<String, LogicalTable> mapping ) {
+    validateConceptId( table, mapping, "XmiParser.ERROR_0012_INVALID_TABLE_ID" );
+
+    Map<String, LogicalColumn> columnsMapping = createIdToConceptMapping( table.getLogicalColumns() );
+    for ( LogicalColumn column : table.getLogicalColumns() ) {
+      validateColumn( column, columnsMapping );
+    }
+  }
+
+  private void validateColumn( LogicalColumn column, Map<String, LogicalColumn> mapping ) {
+    validateConceptId( column, mapping, "XmiParser.ERROR_0012_INVALID_COLUMN_ID" );
+  }
+
+  private void validateCategory( Category category, Map<String, Category> mapping ) {
+    validateConceptId( category, mapping, "XmiParser.ERROR_0012_INVALID_CATEGORY_ID" );
+  }
+
+  private static <T extends Concept> Map<String, T> createIdToConceptMapping(List<T> concepts) {
+    Map<String, T> map = new HashMap<String, T>( concepts.size() );
+    for ( T concept : concepts ) {
+      map.put( concept.getId(), concept );
+    }
+    return map;
+  }
+
+  private static <T extends Concept> void validateConceptId( T concept, Map<String, T> siblings, String i18nKey ) {
+    String id = concept.getId();
+    if (!Util.validateId( id )) {
+      String newId = Util.toId( id );
+
+      int n = 1;
+      String tmp = newId;
+      while ( siblings.containsKey( tmp ) ) {
+        tmp = newId + n;
+        n++;
+      }
+      newId = tmp;
+
+      siblings.remove( id );
+      siblings.put( newId, concept );
+
+      concept.setId( newId );
+      logger.info( Messages.getString( i18nKey, id, newId ) );
+    }
+  }
+
 
   private static Map<String, String> getKeyValuePairs( Element parent, String childName, String keyAttrib,
       String valAttrib ) {

--- a/src/org/pentaho/pms/factory/CwmSchemaFactory.java
+++ b/src/org/pentaho/pms/factory/CwmSchemaFactory.java
@@ -35,6 +35,7 @@ import org.pentaho.di.core.ProgressMonitorListener;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.metadata.util.Util;
 import org.pentaho.pms.core.CWM;
 import org.pentaho.pms.core.exception.PentahoMetadataException;
 import org.pentaho.pms.cwm.pentaho.meta.behavioral.CwmEvent;
@@ -944,7 +945,12 @@ public class CwmSchemaFactory implements CwmSchemaFactoryInterface {
    */
   public BusinessTable getBusinessTable( CWM cwm, CwmDimension cwmDimension, SchemaMeta schemaMeta,
       BusinessModel businessModel ) {
-    BusinessTable businessTable = new BusinessTable( cwmDimension.getName() );
+    String proposedTableId = cwmDimension.getName();
+    if ( !Util.validateId( proposedTableId )) {
+      proposedTableId = Util.toId( proposedTableId );
+    }
+
+    BusinessTable businessTable = new BusinessTable( proposedTableId );
     businessTable
         .addIDChangedListener( ConceptUtilityBase.createIDChangedListener( businessModel.getBusinessTables() ) );
 
@@ -1059,7 +1065,11 @@ public class CwmSchemaFactory implements CwmSchemaFactoryInterface {
    */
   public BusinessColumn getBusinessColumn( CWM cwm, CwmDimensionedObject cwmDimensionedObject,
       PhysicalTable physicalTable, BusinessTable businessTable, SchemaMeta schemaMeta ) {
-    BusinessColumn businessColumn = new BusinessColumn( cwmDimensionedObject.getName() );
+    String proposedTableId = cwmDimensionedObject.getName();
+    if (!Util.validateId( proposedTableId )) {
+      proposedTableId = Util.toId( proposedTableId );
+    }
+    BusinessColumn businessColumn = new BusinessColumn( proposedTableId );
     businessColumn.addIDChangedListener( ConceptUtilityBase
         .createIDChangedListener( businessTable.getBusinessColumns() ) );
 
@@ -1363,7 +1373,12 @@ public class CwmSchemaFactory implements CwmSchemaFactoryInterface {
    */
   public BusinessCategory getBusinessCategory( CWM cwm, CwmExtent cwmExtent, BusinessModel businessModel,
       SchemaMeta schemaMeta ) {
-    BusinessCategory businessCategory = new BusinessCategory( cwmExtent.getName() );
+    String proposedCategoryId = cwmExtent.getName();
+    if ( !Util.validateId( proposedCategoryId )) {
+      proposedCategoryId = Util.toId( proposedCategoryId );
+    }
+
+    BusinessCategory businessCategory = new BusinessCategory( proposedCategoryId );
     businessCategory.addIDChangedListener( ConceptUtilityBase.createIDChangedListener( businessModel.getRootCategory()
         .getBusinessCategories() ) );
 

--- a/src/org/pentaho/pms/schema/concept/ConceptUtilityBase.java
+++ b/src/org/pentaho/pms/schema/concept/ConceptUtilityBase.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.pentaho.di.core.changed.ChangedFlag;
+import org.pentaho.metadata.util.Util;
 import org.pentaho.pms.core.event.AllowsIDChangeListenersInterface;
 import org.pentaho.pms.core.event.IDChangedEvent;
 import org.pentaho.pms.core.event.IDChangedListener;
@@ -50,7 +51,6 @@ import org.pentaho.pms.util.ObjectAlreadyExistsException;
 import org.pentaho.pms.util.UniqueList;
 
 /**
- * 
  * @deprecated as of metadata 3.0.
  */
 public class ConceptUtilityBase extends ChangedFlag implements AllowsIDChangeListenersInterface {
@@ -128,10 +128,8 @@ public class ConceptUtilityBase extends ChangedFlag implements AllowsIDChangeLis
   }
 
   /**
-   * @param id
-   *          the id to set
-   * @throws ObjectAlreadyExistsException
-   *           in case the ID already exists in a parent list (UniqueList)
+   * @param id the id to set
+   * @throws ObjectAlreadyExistsException in case the ID already exists in a parent list (UniqueList)
    */
   public void setId( String id ) throws ObjectAlreadyExistsException {
     // Verify uniqueness BEFORE we change the ID!
@@ -146,7 +144,7 @@ public class ConceptUtilityBase extends ChangedFlag implements AllowsIDChangeLis
         listener.IDChanged( new IDChangedEvent( this.id, id, this ) );
       } catch ( ObjectAlreadyExistsException e ) {
         throw new ObjectAlreadyExistsException( Messages.getString(
-            "ConceptUtilityBase.ERROR_0001_OBJECT_ID_EXISTS", id ), e ); //$NON-NLS-1$
+          "ConceptUtilityBase.ERROR_0001_OBJECT_ID_EXISTS", id ), e ); //$NON-NLS-1$
       }
     }
     this.id = id;
@@ -161,8 +159,7 @@ public class ConceptUtilityBase extends ChangedFlag implements AllowsIDChangeLis
   }
 
   /**
-   * @param concept
-   *          The concept to set
+   * @param concept The concept to set
    */
   public void setConcept( ConceptInterface concept ) {
     this.concept = concept;
@@ -172,9 +169,8 @@ public class ConceptUtilityBase extends ChangedFlag implements AllowsIDChangeLis
   /**
    * Returns the display name for the concept using the specified locale. If the concept doesn't have a display name
    * given the specified locale, the default locale will be used
-   * 
-   * @param locale
-   *          The prefered locale to go for
+   *
+   * @param locale The prefered locale to go for
    * @return The localized name or the id if nothing was found for that or the default locale
    */
   public String getDisplayName( String locale ) {
@@ -184,11 +180,9 @@ public class ConceptUtilityBase extends ChangedFlag implements AllowsIDChangeLis
 
   /**
    * Set the localized name of the object
-   * 
-   * @param locale
-   *          The prefered locale to go for
-   * @param name
-   *          the name to set
+   *
+   * @param locale The prefered locale to go for
+   * @param name   the name to set
    */
   public void setName( String locale, String name ) {
     concept.setName( locale, name );
@@ -197,9 +191,8 @@ public class ConceptUtilityBase extends ChangedFlag implements AllowsIDChangeLis
   /**
    * Returns the name for the concept using the specified locale. If the concept doesn't have a name given the specified
    * locale, the default locale will be used
-   * 
-   * @param locale
-   *          The prefered locale to go for
+   *
+   * @param locale The prefered locale to go for
    * @return The localized name or the id if nothing was found for that or the default locale
    */
   public String getName( String locale ) {
@@ -225,20 +218,16 @@ public class ConceptUtilityBase extends ChangedFlag implements AllowsIDChangeLis
 
   /**
    * Set the localized description of the object
-   * 
-   * @param locale
-   *          The prefered locale to go for
-   * @param description
-   *          the description to set
-   * 
+   *
+   * @param locale      The prefered locale to go for
+   * @param description the description to set
    */
   public void setDescription( String locale, String description ) {
     concept.setDescription( locale, description );
   }
 
   /**
-   * @param locale
-   *          The prefered locale to go for
+   * @param locale The prefered locale to go for
    * @return The localized description or null if nothing was found for that locale
    */
   public String getDescription( String locale ) {
@@ -393,8 +382,7 @@ public class ConceptUtilityBase extends ChangedFlag implements AllowsIDChangeLis
   }
 
   /**
-   * @param columnType
-   *          the column type to set
+   * @param columnType the column type to set
    */
   public void setFieldType( FieldTypeSettings fieldType ) {
     ConceptPropertyInterface property = concept.getChildProperty( DefaultPropertyID.FIELD_TYPE.getId() );
@@ -436,7 +424,7 @@ public class ConceptUtilityBase extends ChangedFlag implements AllowsIDChangeLis
       property.setValue( aggregationList );
     } else {
       concept.addProperty( new ConceptPropertyAggregationList( DefaultPropertyID.AGGREGATION_LIST.getId(),
-          aggregationList ) );
+        aggregationList ) );
     }
   }
 
@@ -555,7 +543,7 @@ public class ConceptUtilityBase extends ChangedFlag implements AllowsIDChangeLis
       property.setValue( rowLevelSecurity );
     } else {
       concept.addProperty( new ConceptPropertyRowLevelSecurity( DefaultPropertyID.ROW_LEVEL_SECURITY.getId(),
-          rowLevelSecurity ) );
+        rowLevelSecurity ) );
     }
   }
 
@@ -577,6 +565,10 @@ public class ConceptUtilityBase extends ChangedFlag implements AllowsIDChangeLis
           return; // no problem
         }
 
+        if ( !Util.validateId( event.newID ) ) {
+          throw Util.idValidationFailed( event.newID );
+        }
+
         // The ID has changed
         // See if the new ID conflicts with one in the list...
         //
@@ -587,7 +579,7 @@ public class ConceptUtilityBase extends ChangedFlag implements AllowsIDChangeLis
             if ( base.getId().equals( event.newID ) ) {
               // This is a problem...
               throw new ObjectAlreadyExistsException( Messages.getString(
-                  "ConceptUtilityBase.ERROR_0001_OBJECT_ID_EXISTS", event.newID ) ); //$NON-NLS-1$
+                "ConceptUtilityBase.ERROR_0001_OBJECT_ID_EXISTS", event.newID ) ); //$NON-NLS-1$
             }
           }
         }
@@ -601,8 +593,8 @@ public class ConceptUtilityBase extends ChangedFlag implements AllowsIDChangeLis
       for ( int i = 0; i < list.size(); i++ ) {
         DefaultProperty defaultProperty = (DefaultProperty) list.get( i );
         ConceptPropertyInterface prop =
-            DefaultPropertyID.getDefaultEmptyProperty( defaultProperty.getConceptPropertyType(), defaultProperty
-                .getName() );
+          DefaultPropertyID.getDefaultEmptyProperty( defaultProperty.getConceptPropertyType(), defaultProperty
+            .getName() );
         prop.setRequired( true );
         concept.addProperty( prop );
       }

--- a/test/org/pentaho/metadata/util/UtilTest.java
+++ b/test/org/pentaho/metadata/util/UtilTest.java
@@ -1,21 +1,61 @@
 package org.pentaho.metadata.util;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class UtilTest {
+
+  private static Map<String, String> prepareCorrectionMapping() {
+    Map<String, String> result = new HashMap<String, String>();
+    result.put( "\"Hello World\"", "Hello_World" );
+    result.put( "`Hello World`", "Hello_World" );
+    result.put( "'Hello World'", "Hello_World" );
+    result.put( "\"Hello*World\"", "Hello_TIMES_World" );
+    result.put( "\"Hello.World\"", "Hello_World" );
+    result.put( "\"Hello/World\"", "Hello_DIVIDED_BY_World" );
+    result.put( "\"Hello+World\"", "Hello_PLUS_World" );
+    result.put( "{[Hello].(World)}", "_Hello_World_" );
+    return result;
+  }
 
   @Test
   public void testToId() {
-    assertEquals( "Hello_World", Util.toId( "\"Hello World\"" ) );
-    assertEquals( "Hello_World", Util.toId( "`Hello World`" ) );
-    assertEquals( "Hello_World", Util.toId( "'Hello World'" ) );
-    assertEquals( "Hello_TIMES_World", Util.toId( "\"Hello*World\"" ) );
-    assertEquals( "Hello_World", Util.toId( "\"Hello.World\"" ) );
-    assertEquals( "Hello_DIVIDED_BY_World", Util.toId( "\"Hello/World\"" ) );
-    assertEquals( "Hello_PLUS_World", Util.toId( "\"Hello+World\"" ) );
-    assertEquals( "_Hello_World_", Util.toId( "{[Hello].(World)}" ) );
+    for ( Map.Entry<String, String> entry : prepareCorrectionMapping().entrySet() ) {
+      assertEquals( entry.getValue(), Util.toId( entry.getKey() ) );
+    }
   }
 
+  @Test
+  public void validateId_Acceptable() {
+    assertTrue( Util.validateId( "qwerty" ) );
+    assertTrue( Util.validateId( "qwerty1" ) );
+    assertTrue( Util.validateId( "0qwerty" ) );
+    assertTrue( Util.validateId( "qwerty_1" ) );
+    assertTrue( Util.validateId( "qwerty_$1" ) );
+    assertTrue( Util.validateId( "qWerTy_$1" ) );
+  }
+
+  @Test
+  public void validateId_ValidateTestToIdSamples() {
+    for ( Map.Entry<String, String> entry : prepareCorrectionMapping().entrySet() ) {
+      assertFalse( entry.getKey(), Util.validateId( entry.getKey() ) );
+      assertTrue( entry.getValue(), Util.validateId( entry.getValue() ) );
+    }
+  }
+
+  @Test
+  public void validateId_Null() {
+    assertFalse( Util.validateId( null ) );
+  }
+
+  @Test
+  public void validateId_Empty() {
+    assertFalse( Util.validateId( "" ) );
+  }
 }

--- a/test/org/pentaho/pms/factory/CwmSchemaFactoryTest.java
+++ b/test/org/pentaho/pms/factory/CwmSchemaFactoryTest.java
@@ -1,0 +1,177 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2006 - 2009 Pentaho Corporation..  All rights reserved.
+ */
+package org.pentaho.pms.factory;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.metadata.util.Util;
+import org.pentaho.pms.core.CWM;
+import org.pentaho.pms.cwm.pentaho.meta.businessinformation.CwmDescription;
+import org.pentaho.pms.cwm.pentaho.meta.core.CwmModelElement;
+import org.pentaho.pms.cwm.pentaho.meta.instance.CwmExtent;
+import org.pentaho.pms.cwm.pentaho.meta.multidimensional.CwmDimension;
+import org.pentaho.pms.cwm.pentaho.meta.multidimensional.CwmDimensionedObject;
+import org.pentaho.pms.schema.BusinessCategory;
+import org.pentaho.pms.schema.BusinessColumn;
+import org.pentaho.pms.schema.BusinessModel;
+import org.pentaho.pms.schema.BusinessTable;
+import org.pentaho.pms.schema.PhysicalColumn;
+import org.pentaho.pms.schema.PhysicalTable;
+import org.pentaho.pms.schema.SchemaMeta;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static org.pentaho.pms.core.CWM.TAG_TABLE_IS_DRAWN;
+import static org.pentaho.pms.core.CWM.TAG_CONCEPT_PARENT_NAME;
+import static org.pentaho.pms.core.CWM.TAG_BUSINESS_TABLE_PHYSICAL_TABLE_NAME;
+import static org.pentaho.pms.core.CWM.TAG_BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+@SuppressWarnings( "deprecation" )
+public class CwmSchemaFactoryTest {
+
+  private static final String TEST_DOMAIN = "Test Domain";
+
+  private static final String PHYSICAL_COL = "physicalColumn";
+  private static final String PHYSICAL_TBL = "PhysicalTable";
+  private static final String BUSINESS_TBL = "BusinessTable";
+
+  private CwmSchemaFactory factory;
+  private CWM cwm;
+
+  @BeforeClass
+  public static void setUpEnv() throws Exception {
+    KettleEnvironment.init( false );
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    factory = new CwmSchemaFactory();
+
+    cwm = CWM.getInstance( TEST_DOMAIN );
+    cwm = spy( cwm );
+
+    doReturn( null ).when( cwm ).getFirstTaggedValue( any( CwmModelElement.class ), eq( TAG_CONCEPT_PARENT_NAME ) );
+    doReturn( "N" ).when( cwm ).getFirstTaggedValue( any( CwmModelElement.class ), eq( TAG_TABLE_IS_DRAWN ) );
+    doReturn( PHYSICAL_TBL ).when( cwm )
+      .getFirstTaggedValue( any( CwmModelElement.class ), eq( TAG_BUSINESS_TABLE_PHYSICAL_TABLE_NAME ) );
+    doReturn( PHYSICAL_COL ).when( cwm )
+      .getFirstTaggedValue( any( CwmModelElement.class ), eq( TAG_BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME ) );
+
+    doReturn( new CwmDescription[ 0 ] ).when( cwm ).getDescription( any( CwmModelElement.class ) );
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    factory = null;
+
+    cwm.removeDomain();
+    cwm = null;
+  }
+
+
+  @Test
+  public void getBusinessColumn_InvalidColumnId() throws Exception {
+    String invalidId = "Territory (Cat Id)";
+    assertFalse( Util.validateId( invalidId ) );
+
+    assertGetBusinessColumn( invalidId, Util.toId( invalidId ) );
+  }
+
+  @Test
+  public void getBusinessColumn_ValidColumnId() throws Exception {
+    String validId = "Territory";
+    assertTrue( Util.validateId( validId ) );
+
+    assertGetBusinessColumn( validId, validId );
+  }
+
+  private void assertGetBusinessColumn( String rawId, String expectedId ) throws Exception {
+    CwmDimensionedObject object = mock( CwmDimensionedObject.class );
+    when( object.getName() ).thenReturn( rawId );
+
+    PhysicalTable physicalTable = new PhysicalTable( PHYSICAL_TBL );
+    physicalTable.addPhysicalColumn( new PhysicalColumn( PHYSICAL_COL ) );
+
+    BusinessColumn column =
+      factory.getBusinessColumn( cwm, object, physicalTable, new BusinessTable( BUSINESS_TBL ), new SchemaMeta() );
+    assertEquals( expectedId, column.getId() );
+  }
+
+
+  @Test
+  public void getBusinessTable_InvalidTableId() throws Exception {
+    String invalidId = "Table (tbl)";
+    assertFalse( Util.validateId( invalidId ) );
+
+    assertGetBusinessTable( invalidId, Util.toId( invalidId ) );
+  }
+
+  @Test
+  public void getBusinessTable_ValidTableId() throws Exception {
+    String validId = "Table";
+    assertTrue( Util.validateId( validId ) );
+
+    assertGetBusinessTable( validId, validId );
+  }
+
+  private void assertGetBusinessTable( String rawId, String expectedId ) throws Exception {
+    CwmDimension dimension = mock( CwmDimension.class );
+    when( dimension.getName() ).thenReturn( rawId );
+
+    SchemaMeta meta = new SchemaMeta();
+    meta.addTable( new PhysicalTable( PHYSICAL_TBL ) );
+
+    BusinessTable column =
+      factory.getBusinessTable( cwm, dimension, meta, new BusinessModel( "businessModel" ) );
+    assertEquals( expectedId, column.getId() );
+  }
+
+
+  @Test
+  public void getBusinessCategory_InvalidCategoryId() throws Exception {
+    String invalidId = "Category (cat)";
+    assertFalse( Util.validateId( invalidId ) );
+
+    assertGetBusinessCategory( invalidId, Util.toId( invalidId ) );
+  }
+
+  @Test
+  public void getBusinessCategory_ValidCategoryId() throws Exception {
+    String validId = "Category";
+    assertTrue( Util.validateId( validId ) );
+
+    assertGetBusinessCategory( validId, validId );
+  }
+
+  private void assertGetBusinessCategory( String rawId, String expectedId ) throws Exception {
+    CwmExtent extent = mock( CwmExtent.class );
+    when( extent.getName() ).thenReturn( rawId );
+
+    SchemaMeta meta = new SchemaMeta();
+    meta.addTable( new PhysicalTable( PHYSICAL_TBL ) );
+
+    BusinessCategory category =
+      factory.getBusinessCategory( cwm, extent, new BusinessModel( "businessModel" ), meta );
+    assertEquals( expectedId, category.getId() );
+  }
+}


### PR DESCRIPTION
... and ")", not working in interactive report prompts

- prohibit extra chars in ids
- add a correction routine to the end of XmiParser.parse()

@mbatchelor, @wseyler, review it please 