### PR TITLE
[BACKLOG-3830]  Removing the VFS 1.0 dependency.

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -27,7 +27,6 @@
     <dependency org="commons-math" name="commons-math" rev="1.1" transitive="false"/>
     <dependency org="commons-dbcp" name="commons-dbcp" rev="1.2.1" transitive="false"/>
     <dependency org="commons-net" name="commons-net" rev="1.4.1" />
-    <dependency org="commons-vfs" name="commons-vfs" rev="1.0" />
     <dependency org="commons-digester" name="commons-digester" rev="1.8" transitive="false" />
     <dependency org="commons-beanutils" name="commons-beanutils" rev="1.8.0" transitive="false" />
     <dependency org="log4j" name="log4j" rev="1.2.16" transitive="false" />


### PR DESCRIPTION
VFS is not a direct dependency, brought in by kettle-core,
which is being upgraded to VFS 2.