### PR TITLE
[BISERVER-13026] Imported CSV Data Source with Hyphen Character Doesnot Display Correctly

### DIFF
--- a/src/org/pentaho/metadata/automodel/PhysicalTableImporter.java
+++ b/src/org/pentaho/metadata/automodel/PhysicalTableImporter.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2009 Pentaho Corporation.  All rights reserved.
+ * Copyright (c) 2016 Pentaho Corporation.  All rights reserved.
  */
 package org.pentaho.metadata.automodel;
 

--- a/src/org/pentaho/metadata/automodel/PhysicalTableImporter.java
+++ b/src/org/pentaho/metadata/automodel/PhysicalTableImporter.java
@@ -24,6 +24,7 @@ import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.metadata.automodel.importing.strategy.DefaultImportStrategy;
 import org.pentaho.metadata.model.IPhysicalColumn;
 import org.pentaho.metadata.model.SqlPhysicalColumn;
 import org.pentaho.metadata.model.SqlPhysicalTable;
@@ -36,22 +37,12 @@ import org.pentaho.metadata.util.Util;
 
 public class PhysicalTableImporter {
 
-  public static interface ImportStrategy {
+  public interface ImportStrategy {
     boolean shouldInclude( ValueMetaInterface valueMeta );
     String displayName( ValueMetaInterface valueMeta );
   }
 
-  public static final ImportStrategy defaultImportStrategy = new ImportStrategy() {
-    @Override
-    public boolean shouldInclude( final ValueMetaInterface valueMeta ) {
-      return true;
-    }
-
-    @Override
-    public String displayName( final ValueMetaInterface valueMeta ) {
-      return valueMeta.getName();
-    }
-  };
+  static final ImportStrategy defaultImportStrategy = new DefaultImportStrategy();
 
   public static SqlPhysicalTable importTableDefinition(
       Database database, String schemaName, String tableName, String locale ) throws KettleException {
@@ -109,14 +100,9 @@ public class PhysicalTableImporter {
   private static IPhysicalColumn importPhysicalColumnDefinition( ValueMetaInterface v, SqlPhysicalTable physicalTable,
                                                                  String locale,
                                                                  final ImportStrategy importStrategy ) {
-    // The id
+     // The name of the column in the database
     //
-    String id = Util.getPhysicalColumnIdPrefix() + v.getName();
-    id = id.toUpperCase();
-
-    // The name of the column in the database
-    //
-    String dbname = v.getName();
+    String columnName = v.getName();
 
     // The field type?
     //
@@ -126,7 +112,7 @@ public class PhysicalTableImporter {
     //
     SqlPhysicalColumn physicalColumn = new SqlPhysicalColumn( physicalTable );
     physicalColumn.setId( v.getName() );
-    physicalColumn.setTargetColumn( dbname );
+    physicalColumn.setTargetColumn( columnName );
     physicalColumn.setFieldType( fieldType );
     physicalColumn.setAggregationType( AggregationType.NONE );
 

--- a/src/org/pentaho/metadata/automodel/importing/strategy/CsvDatasourceImportStrategy.java
+++ b/src/org/pentaho/metadata/automodel/importing/strategy/CsvDatasourceImportStrategy.java
@@ -1,0 +1,78 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+
+package org.pentaho.metadata.automodel.importing.strategy;
+
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.metadata.automodel.PhysicalTableImporter;
+import org.pentaho.metadata.model.thin.Column;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class is responsible for binding column id's and column names, so as to provide friendly column name
+ * by column id.
+ *
+ * When we create csv data source, we can specify column names with the chars that are not allowed
+ * for MDX queries. They will be replaced with legal chars in database level, but they should be displayed
+ * as they are, with no changes.
+ *
+ * Column id here - is the name of the column in database and column name is
+ * originally specified name by user (no matter whether it is valid for MDX queries or not)
+ *
+ *
+ * This should be used only by csv datasource, because it is the only datasource type, where we create a table in db
+ * (and not use the existing). When creating a table we have a list of specified by user column names. Some of them can be invalid
+ * and will be replaced for allowing MDX queries. It's the only case where col id and col name is different. When we are creating
+ * datasource from already existing tables (it's true case for other data sources) we can't modify anything (form UI) in column names
+ * of an existing table, so names and ids will always be the same for this case (which makes use of this class useless)
+ *
+ */
+public class CsvDatasourceImportStrategy implements PhysicalTableImporter.ImportStrategy {
+  private Map<String, String> columnsIdToNameMap;
+
+  public CsvDatasourceImportStrategy( Column[] columns ) {
+    columnsIdToNameMap = new HashMap<>(  );
+    bindIdsToNames( columns );
+  }
+
+  private void bindIdsToNames( Column[] columns ) {
+    for ( Column column : columns ) {
+      final String name = column.getName();
+      final String id = column.getId();
+      if ( name != null && id != null ) {
+        columnsIdToNameMap.put( column.getId(), column.getName() );
+      }
+    }
+  }
+
+  @Override
+  public boolean shouldInclude( ValueMetaInterface valueMeta ) {
+    return true;
+  }
+
+  @Override
+  public String displayName( ValueMetaInterface valueMeta ) {
+    // it's an id (column name on database level) actually.
+    final String columnId = valueMeta.getName();
+    final String columnName = columnsIdToNameMap.get( columnId );
+
+    return columnName == null ? columnId : columnName;
+  }
+}

--- a/src/org/pentaho/metadata/automodel/importing/strategy/DefaultImportStrategy.java
+++ b/src/org/pentaho/metadata/automodel/importing/strategy/DefaultImportStrategy.java
@@ -21,14 +21,14 @@ import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.metadata.automodel.PhysicalTableImporter;
 
 public class DefaultImportStrategy implements PhysicalTableImporter.ImportStrategy {
-@Override
-public boolean shouldInclude( final ValueMetaInterface valueMeta ) {
-  return true;
+
+  @Override
+  public boolean shouldInclude( final ValueMetaInterface valueMeta ) {
+    return true;
   }
 
-@Override
-public String displayName( final ValueMetaInterface valueMeta ) {
-  return valueMeta.getName();
+  @Override
+  public String displayName( final ValueMetaInterface valueMeta ) {
+    return valueMeta.getName();
   }
-
 }

--- a/src/org/pentaho/metadata/automodel/importing/strategy/DefaultImportStrategy.java
+++ b/src/org/pentaho/metadata/automodel/importing/strategy/DefaultImportStrategy.java
@@ -1,0 +1,34 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.metadata.automodel.importing.strategy;
+
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.metadata.automodel.PhysicalTableImporter;
+
+public class DefaultImportStrategy implements PhysicalTableImporter.ImportStrategy {
+@Override
+public boolean shouldInclude( final ValueMetaInterface valueMeta ) {
+  return true;
+  }
+
+@Override
+public String displayName( final ValueMetaInterface valueMeta ) {
+  return valueMeta.getName();
+  }
+
+}

--- a/test-src/org/pentaho/metadata/automodel/CsvDataSourceImportStrategyTest.java
+++ b/test-src/org/pentaho/metadata/automodel/CsvDataSourceImportStrategyTest.java
@@ -1,0 +1,62 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.metadata.automodel;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.metadata.automodel.importing.strategy.CsvDatasourceImportStrategy;
+import org.pentaho.metadata.model.thin.Column;
+
+public class CsvDataSourceImportStrategyTest {
+
+  @Test
+  public void nameWithProhibitChars_DisplayedWithNoChanges() {
+    final String nameWithProhibitChars = "Month 1-2";
+    final String id = "Month 1_HYPHEN_2";
+
+    Column[] columns = new Column[] { createColumn( id, nameWithProhibitChars ) };
+
+    CsvDatasourceImportStrategy importStrategy = new CsvDatasourceImportStrategy( columns );
+    ValueMetaInterface meta = new ValueMetaString( id );
+
+    Assert.assertEquals( importStrategy.displayName( meta ), nameWithProhibitChars );
+  }
+
+  @Test
+  public void nameWithNoProhibitChars_DisplayedWithNoChanges() {
+    final String nameWithProhibitChars = "Month 1";
+    final String id = "Month 1";
+
+    Column[] columns = new Column[] { createColumn( id, nameWithProhibitChars ) };
+
+    CsvDatasourceImportStrategy importStrategy = new CsvDatasourceImportStrategy( columns );
+    ValueMetaInterface meta = new ValueMetaString( id );
+
+    Assert.assertEquals( importStrategy.displayName( meta ), nameWithProhibitChars );
+  }
+
+  private Column createColumn( String id, String name ) {
+    Column column = new Column();
+    column.setId( id );
+    column.setName( name );
+
+    return column;
+  }
+}


### PR DESCRIPTION
- Added CsvDatasourceImportStrategy class, that is responsible for binding column id's and column names, so as to provide friendly column name by column id, and will be used when creating csv type datasource. Please see javadocks of this class for more info.
- All children of ImportStrategy interface gathered in one package.
- Refactored few typos and removed dead-code in PhysicalTableImporter class.
- Tests written

It's a part of fix. Here is another one:  https://github.com/IvanNikolaychuk/data-access/commit/6f43573f1385c3137cd992e2f166ab28b854255a. It won't compile without merging this PR, so I will sent it after mergining this one.

@rmansoor , could you please review it? 
