### PR TITLE
[BISERVER-13026] Imported CSV Data Source with Hyphen Character Doesnot Display Correctly

### DIFF
--- a/src/org/pentaho/metadata/automodel/PhysicalTableImporter.java
+++ b/src/org/pentaho/metadata/automodel/PhysicalTableImporter.java
@@ -42,7 +42,7 @@ public class PhysicalTableImporter {
     String displayName( ValueMetaInterface valueMeta );
   }
 
-  static final ImportStrategy defaultImportStrategy = new DefaultImportStrategy();
+  public static final ImportStrategy defaultImportStrategy = new DefaultImportStrategy();
 
   public static SqlPhysicalTable importTableDefinition(
       Database database, String schemaName, String tableName, String locale ) throws KettleException {


### PR DESCRIPTION
In https://github.com/pentaho/pentaho-metadata/pull/91 I changing defaultImportStrategy visibility to package locale for better encopsulation, but it looks like this field is used directly in pentaho-modeler project.

@pamval , review it please