### PR TITLE
[PPP-3506] Data-Access has XXE Security Vulnerability when importing Metadata

### DIFF
--- a/src/org/pentaho/metadata/query/model/util/QueryXmlHelper.java
+++ b/src/org/pentaho/metadata/query/model/util/QueryXmlHelper.java
@@ -45,6 +45,7 @@ import org.pentaho.metadata.query.model.Parameter;
 import org.pentaho.metadata.query.model.Query;
 import org.pentaho.metadata.query.model.Selection;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
+import org.pentaho.metadata.util.XmiParser;
 import org.pentaho.pms.core.exception.PentahoMetadataException;
 import org.pentaho.reporting.libraries.base.util.CSVTokenizer;
 import org.w3c.dom.Document;
@@ -96,14 +97,11 @@ public class QueryXmlHelper {
       return null;
     }
 
-    DocumentBuilderFactory dbf;
-    DocumentBuilder db;
     Document doc;
-
     try {
       // create an XML document
-      dbf = DocumentBuilderFactory.newInstance();
-      db = dbf.newDocumentBuilder();
+      DocumentBuilderFactory dbf = XmiParser.createSecureDocBuilderFactory();
+      DocumentBuilder db = dbf.newDocumentBuilder();
       doc = db.newDocument();
       Element mqlElement = doc.createElement( "mql" ); //$NON-NLS-1$
       doc.appendChild( mqlElement );
@@ -320,14 +318,12 @@ public class QueryXmlHelper {
     if ( XML == null ) {
       throw new PentahoMetadataException( Messages.getErrorString( "QueryXmlHelper.ERROR_0008_XML_NULL" ) ); //$NON-NLS-1$
     }
-    DocumentBuilderFactory dbf;
-    DocumentBuilder db;
     Document doc;
 
     // Check and open XML document
-    dbf = DocumentBuilderFactory.newInstance();
     try {
-      db = dbf.newDocumentBuilder();
+      DocumentBuilderFactory dbf = XmiParser.createSecureDocBuilderFactory();
+      DocumentBuilder db = dbf.newDocumentBuilder();
       doc = db.parse( new InputSource( new java.io.StringReader( XML ) ) );
     } catch ( ParserConfigurationException pcx ) {
       throw new PentahoMetadataException( pcx );

--- a/src/org/pentaho/metadata/query/model/util/QueryXmlHelper.java
+++ b/src/org/pentaho/metadata/query/model/util/QueryXmlHelper.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2009 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2009 - 2016 Pentaho Corporation..  All rights reserved.
  */
 package org.pentaho.metadata.query.model.util;
 

--- a/src/org/pentaho/metadata/util/XmiParser.java
+++ b/src/org/pentaho/metadata/util/XmiParser.java
@@ -925,9 +925,7 @@ public class XmiParser {
         type = "Font"; //$NON-NLS-1$
       } else if ( val instanceof TargetTableType ) {
         TargetTableType ttt = (TargetTableType) val;
-        if ( ttt == TargetTableType.TABLE ) {
-          // do nothing
-        } else {
+        if ( !( ttt == TargetTableType.TABLE ) ) {
           type = "TargetTableType"; //$NON-NLS-1$
           body = ttt.toString();
         }
@@ -982,11 +980,9 @@ public class XmiParser {
           } else if ( objs.get( 0 ) instanceof OlapRole ) {
             body = OlapUtil.toXmlRoles( (List<OlapRole>) objs );
             type = "String";
-          } else if ( objs.get( 0 ) instanceof OlapCube || objs.get( 0 ) instanceof OlapDimension ) {
-            // ignore
-          } else {
+          } else if ( !( objs.get( 0 ) instanceof OlapCube || objs.get( 0 ) instanceof OlapDimension ) ) {
             logger.error( Messages.getErrorString(
-                "XmiParser.ERROR_0004_UNSUPPORTED_CONCEPT_PROPERTY_LIST", objs.get( 0 ).getClass() ) ); //$NON-NLS-1$
+              "XmiParser.ERROR_0004_UNSUPPORTED_CONCEPT_PROPERTY_LIST", objs.get( 0 ).getClass() ) ); //$NON-NLS-1$
           }
         }
       } else {
@@ -1724,13 +1720,12 @@ public class XmiParser {
               } else if ( dimensionChildren.item( j ).getNodeName()
                   .equals( "CWMOLAP:Dimension.memberSelection" ) ) { //$NON-NLS-1$
                 memberSelections = (Element) dimensionChildren.item( j );
-              } else if ( dimensionChildren.item( j ).getNodeName().equals(
-                  "CWMOLAP:Dimension.cubeDimensionAssociation" ) ) { //$NON-NLS-1$
-                // ignored, cubes and dimensions are mapped later through dimension usages.
-              } else {
+              } else if ( !dimensionChildren.item( j ).getNodeName().equals(
+                "CWMOLAP:Dimension.cubeDimensionAssociation" ) ) { //$NON-NLS-1$
+                //  cubes and dimensions are mapped later through dimension usages.
                 if ( logger.isDebugEnabled() ) {
                   logger
-                      .debug( "Dimension object ignored: " + dimensionChildren.item( j ).getNodeName() ); //$NON-NLS-1$
+                    .debug( "Dimension object ignored: " + dimensionChildren.item( j ).getNodeName() ); //$NON-NLS-1$
                 }
               }
             }
@@ -1920,8 +1915,6 @@ public class XmiParser {
             if ( dimensionLinks.getLength() == 1 ) {
               Element dimensionLink = (Element) dimensionLinks.item( 0 );
               dimUsage.setOlapDimension( dimensionMap.get( dimensionLink.getAttribute( "xmi.idref" ) ) ); //$NON-NLS-1$
-            } else {
-              // BAD
             }
           }
           cubeObj.setOlapDimensionUsages( dimensionUsages );

--- a/src/org/pentaho/pms/mql/MQLQueryImpl.java
+++ b/src/org/pentaho/pms/mql/MQLQueryImpl.java
@@ -33,6 +33,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.metadata.util.XmiParser;
 import org.pentaho.pms.core.CWM;
 import org.pentaho.pms.core.exception.PentahoMetadataException;
 import org.pentaho.pms.factory.CwmSchemaFactoryInterface;
@@ -222,14 +223,12 @@ public class MQLQueryImpl implements MQLQuery {
   }
 
   public Document getDocument() {
-    DocumentBuilderFactory dbf;
-    DocumentBuilder db;
     Document doc;
 
     try {
       // create an XML document
-      dbf = DocumentBuilderFactory.newInstance();
-      db = dbf.newDocumentBuilder();
+      DocumentBuilderFactory dbf = XmiParser.createSecureDocBuilderFactory();
+      DocumentBuilder db = dbf.newDocumentBuilder();
       doc = db.newDocument();
       Element mqlElement = doc.createElement( "mql" ); //$NON-NLS-1$
       doc.appendChild( mqlElement );
@@ -429,15 +428,13 @@ public class MQLQueryImpl implements MQLQuery {
     if ( XML == null ) {
       throw new PentahoMetadataException( Messages.getErrorString( "MQLQuery.ERROR_0017_XML_NULL" ) ); //$NON-NLS-1$
     }
-    DocumentBuilderFactory dbf;
-    DocumentBuilder db;
-    Document doc;
 
+    Document doc;
     // Check and open XML document
-    dbf = DocumentBuilderFactory.newInstance();
     try {
-      db = dbf.newDocumentBuilder();
-      doc = db.parse( new InputSource( new java.io.StringReader( XML ) ) );
+      DocumentBuilderFactory dbf = XmiParser.createSecureDocBuilderFactory();
+      DocumentBuilder docBuilder = dbf.newDocumentBuilder();
+      doc = docBuilder.parse( new InputSource( new java.io.StringReader( XML ) ) );
     } catch ( ParserConfigurationException pcx ) {
       throw new PentahoMetadataException( pcx );
     } catch ( SAXException sex ) {
@@ -452,14 +449,12 @@ public class MQLQueryImpl implements MQLQuery {
     if ( XML == null ) {
       throw new PentahoMetadataException( Messages.getErrorString( "MQLQuery.ERROR_0017_XML_NULL" ) ); //$NON-NLS-1$
     }
-    DocumentBuilderFactory dbf;
-    DocumentBuilder db;
-    Document doc;
 
+    Document doc;
     // Check and open XML document
-    dbf = DocumentBuilderFactory.newInstance();
     try {
-      db = dbf.newDocumentBuilder();
+      DocumentBuilderFactory dbf = XmiParser.createSecureDocBuilderFactory();
+      DocumentBuilder db = dbf.newDocumentBuilder();
       doc = db.parse( new InputSource( new java.io.StringReader( XML ) ) );
     } catch ( ParserConfigurationException pcx ) {
       throw new PentahoMetadataException( pcx );

--- a/src/org/pentaho/pms/mql/MQLQueryImpl.java
+++ b/src/org/pentaho/pms/mql/MQLQueryImpl.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2006 - 2009 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2006 - 2016 Pentaho Corporation..  All rights reserved.
  */
 package org.pentaho.pms.mql;
 
@@ -579,9 +579,9 @@ public class MQLQueryImpl implements MQLQuery {
     this.disableDistinct = false;
     this.limit = -1;
     if ( optionElement != null ) {
-      String disableStr = getElementText( optionElement, "disable_distinct" );//$NON-NLS-1$
+      String disableStr = getElementText( optionElement, "disable_distinct" ); //$NON-NLS-1$
       if ( disableStr != null ) {
-        this.disableDistinct = disableStr.equalsIgnoreCase( "true" );//$NON-NLS-1$
+        this.disableDistinct = disableStr.equalsIgnoreCase( "true" ); //$NON-NLS-1$
       }
       String limitStr = getElementText( optionElement, "limit" );
       if ( limitStr != null ) {

--- a/test-src/org/pentaho/metadata/query/model/util/QueryXmlHelperTest.java
+++ b/test-src/org/pentaho/metadata/query/model/util/QueryXmlHelperTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright 2005 - 2010 Pentaho Corporation.  All rights reserved.
+ * Copyright 2005 - 2016 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.metadata.query.model.util;
@@ -101,7 +101,7 @@ public class QueryXmlHelperTest {
             + "<column>LC_Test_Column1</column>" + "<aggregation>NONE</aggregation>"
             + "</selection><selection>" + "<table>Test</table>" + "<column>LC_Test_Column2</column>"
             + "<aggregation>NONE</aggregation>" + "</selection></selections>" + "<constraints></constraints>"
-            + "<orders></orders>" +"</mql>";
+            + "<orders></orders>" + "</mql>";
     Query q = helper.fromXML( metadataDomainRepository, mql );
 
     assertEquals( 1, q.getSelections().size() );
@@ -109,8 +109,7 @@ public class QueryXmlHelperTest {
   }
 
 
-
-  @Test(expected = PentahoMetadataException.class)
+  @Test( expected = PentahoMetadataException.class )
   public void exceptionThrown_WhenParsingXmlWith_BigNumberOfExternalEntities() throws Exception {
     /**
      * @see  <a href="https://en.wikipedia.org/wiki/Billion_laughs" />
@@ -132,7 +131,7 @@ public class QueryXmlHelperTest {
         + "]>\n"
         + "<lolz>&lol9;</lolz>";
 
-    helper.fromXML( mock(IMetadataDomainRepository.class), maliciousXml );
+    helper.fromXML( mock( IMetadataDomainRepository.class ), maliciousXml );
   }
 
   @Test

--- a/test-src/org/pentaho/metadata/query/model/util/QueryXmlHelperTest.java
+++ b/test-src/org/pentaho/metadata/query/model/util/QueryXmlHelperTest.java
@@ -21,6 +21,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -105,6 +106,33 @@ public class QueryXmlHelperTest {
 
     assertEquals( 1, q.getSelections().size() );
     assertEquals( "LC_Test_Column1", q.getSelections().get( 0 ).getLogicalColumn().getId() );
+  }
+
+
+
+  @Test(expected = PentahoMetadataException.class)
+  public void exceptionThrown_WhenParsingXmlWith_BigNumberOfExternalEntities() throws Exception {
+    /**
+     * @see  <a href="https://en.wikipedia.org/wiki/Billion_laughs" />
+     */
+    final String maliciousXml =
+      "<?xml version=\"1.0\"?>\n"
+        + "<!DOCTYPE lolz [\n"
+        + " <!ENTITY lol \"lol\">\n"
+        + " <!ELEMENT lolz (#PCDATA)>\n"
+        + " <!ENTITY lol1 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">\n"
+        + " <!ENTITY lol2 \"&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;\">\n"
+        + " <!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">\n"
+        + " <!ENTITY lol4 \"&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;\">\n"
+        + " <!ENTITY lol5 \"&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;\">\n"
+        + " <!ENTITY lol6 \"&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;\">\n"
+        + " <!ENTITY lol7 \"&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;\">\n"
+        + " <!ENTITY lol8 \"&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;\">\n"
+        + " <!ENTITY lol9 \"&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;\">\n"
+        + "]>\n"
+        + "<lolz>&lol9;</lolz>";
+
+    helper.fromXML( mock(IMetadataDomainRepository.class), maliciousXml );
   }
 
   @Test

--- a/test-src/org/pentaho/metadata/util/XmiParserTest.java
+++ b/test-src/org/pentaho/metadata/util/XmiParserTest.java
@@ -1,0 +1,61 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2016 Pentaho Corporation.  All rights reserved.
+ */
+package org.pentaho.metadata.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.pentaho.pms.core.exception.PentahoMetadataException;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+
+public class XmiParserTest {
+  /**
+   * @see <a href="https://en.wikipedia.org/wiki/Billion_laughs" />
+   */
+  private static final String MALICIOUS_XML =
+    "<?xml version=\"1.0\"?>\n"
+      + "<!DOCTYPE lolz [\n"
+      + " <!ENTITY lol \"lol\">\n"
+      + " <!ELEMENT lolz (#PCDATA)>\n"
+      + " <!ENTITY lol1 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">\n"
+      + " <!ENTITY lol2 \"&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;\">\n"
+      + " <!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">\n"
+      + " <!ENTITY lol4 \"&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;\">\n"
+      + " <!ENTITY lol5 \"&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;\">\n"
+      + " <!ENTITY lol6 \"&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;\">\n"
+      + " <!ENTITY lol7 \"&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;\">\n"
+      + " <!ENTITY lol8 \"&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;\">\n"
+      + " <!ENTITY lol9 \"&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;\">\n"
+      + "]>\n"
+      + "<lolz>&lol9;</lolz>";
+
+  @Test
+  public void secureFeatureEnabled_AfterDocBuilderFactoryCreation() throws Exception {
+    DocumentBuilderFactory documentBuilderFactory = XmiParser.createSecureDocBuilderFactory();
+    boolean secureFeatureEnabled = documentBuilderFactory.getFeature( XMLConstants.FEATURE_SECURE_PROCESSING );
+
+    Assert.assertEquals( true, secureFeatureEnabled );
+  }
+
+  @Test( expected = PentahoMetadataException.class )
+  public void exceptionThrown_WhenParsingXmlWith_BigNumberOfExternalEntities() throws Exception {
+    XmiParser xmiParser = new XmiParser();
+    xmiParser.parseXmi( new ByteArrayInputStream( MALICIOUS_XML.getBytes() ) );
+  }
+}

--- a/test-src/org/pentaho/pms/mql/MQLQueryTest.java
+++ b/test-src/org/pentaho/pms/mql/MQLQueryTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.mock;
 public class MQLQueryTest {
   private MQLQueryImpl mqlQuery;
 
-  private final static String MALICIOUS_XML =
+  private static final String MALICIOUS_XML =
     "<?xml version=\"1.0\"?>\n"
       + "<!DOCTYPE lolz [\n"
       + " <!ENTITY lol \"lol\">\n"
@@ -48,7 +48,7 @@ public class MQLQueryTest {
 
   @Before
   public void setUp() throws Exception {
-    mqlQuery = mock(MQLQueryImpl.class);
+    mqlQuery = mock( MQLQueryImpl.class );
     doCallRealMethod().when( mqlQuery ).fromXML( anyString() );
     doCallRealMethod().when( mqlQuery ).fromXML( anyString(), any( SchemaMeta.class ) );
   }

--- a/test-src/org/pentaho/pms/mql/MQLQueryTest.java
+++ b/test-src/org/pentaho/pms/mql/MQLQueryTest.java
@@ -1,0 +1,72 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2016 Pentaho Corporation.  All rights reserved.
+ */
+package org.pentaho.pms.mql;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.pms.core.exception.PentahoMetadataException;
+import org.pentaho.pms.schema.SchemaMeta;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+
+public class MQLQueryTest {
+  private MQLQueryImpl mqlQuery;
+
+  private final static String MALICIOUS_XML =
+    "<?xml version=\"1.0\"?>\n"
+      + "<!DOCTYPE lolz [\n"
+      + " <!ENTITY lol \"lol\">\n"
+      + " <!ELEMENT lolz (#PCDATA)>\n"
+      + " <!ENTITY lol1 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">\n"
+      + " <!ENTITY lol2 \"&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;\">\n"
+      + " <!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">\n"
+      + " <!ENTITY lol4 \"&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;\">\n"
+      + " <!ENTITY lol5 \"&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;\">\n"
+      + " <!ENTITY lol6 \"&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;\">\n"
+      + " <!ENTITY lol7 \"&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;\">\n"
+      + " <!ENTITY lol8 \"&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;\">\n"
+      + " <!ENTITY lol9 \"&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;\">\n"
+      + "]>\n"
+      + "<lolz>&lol9;</lolz>";
+
+  @Before
+  public void setUp() throws Exception {
+    mqlQuery = mock(MQLQueryImpl.class);
+    doCallRealMethod().when( mqlQuery ).fromXML( anyString() );
+    doCallRealMethod().when( mqlQuery ).fromXML( anyString(), any( SchemaMeta.class ) );
+  }
+
+  /**
+   * Testing {@link MQLQueryImpl#fromXML(String)} method
+   */
+  @Test( expected = PentahoMetadataException.class )
+  public void exceptionThrown_WhenParsingXmlWith_BigNumberOfExternalEntities1() throws Exception {
+    mqlQuery.fromXML( MALICIOUS_XML );
+  }
+
+
+  /**
+   * Testing {@link MQLQueryImpl#fromXML(String, SchemaMeta)} method
+   */
+  @Test( expected = PentahoMetadataException.class )
+  public void exceptionThrown_WhenParsingXmlWith_BigNumberOfExternalEntities2() throws Exception {
+    mqlQuery.fromXML( MALICIOUS_XML, mock( SchemaMeta.class ) );
+  }
+}


### PR DESCRIPTION
- Setting FEATURE_SECURE_PROCESSING after creating DocumentBuilderFactory instance to prevent XXE attacks with bunch of exponential entities
- Centralizing this method in XmiParser class.
- Tests written

There are still unsecure xml parsers in data-access project.
This PR coveres only pentaho-modeler project.

@rfellows , could you please review it?