### PR TITLE
[BISERVER-13159] Upgrade issue from 5.1 to 5.4 when SQL datasource created via Data Access Wizard has Japanese Columns in it

### DIFF
--- a/src/org/pentaho/metadata/util/Util.java
+++ b/src/org/pentaho/metadata/util/Util.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2009 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2016 Pentaho Corporation..  All rights reserved.
  */
 package org.pentaho.metadata.util;
 
@@ -85,8 +85,8 @@ public class Util {
   }
 
   private static boolean isLatinLetter( char ch ) {
-    return ( ( 'a' <= ch ) && ( ch <= 'z' ) ) ||
-      ( ( 'A' <= ch ) && ( ch <= 'Z' ) );
+    return ( ( 'a' <= ch ) && ( ch <= 'z' ) )
+        || ( ( 'A' <= ch ) && ( ch <= 'Z' ) );
   }
 
   private static boolean isAsciiDigit( char ch ) {

--- a/src/org/pentaho/metadata/util/Util.java
+++ b/src/org/pentaho/metadata/util/Util.java
@@ -16,7 +16,9 @@
  */
 package org.pentaho.metadata.util;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.pentaho.metadata.model.Category;
 import org.pentaho.metadata.model.LogicalColumn;
@@ -30,6 +32,16 @@ import org.pentaho.pms.util.Settings;
 public class Util {
 
   public static final String CR = System.getProperty( "line.separator" ); //$NON-NLS-1$
+
+  private static final Set<Character.UnicodeBlock> acceptableUnicodeBlocks = new HashSet();
+
+  static {
+    acceptableUnicodeBlocks.add( Character.UnicodeBlock.KATAKANA );
+    acceptableUnicodeBlocks.add( Character.UnicodeBlock.HIRAGANA );
+    acceptableUnicodeBlocks.add( Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS );
+    acceptableUnicodeBlocks.add( Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A );
+    // Other legit unicode blocks can be added
+  }
 
   public static String getCategoryIdPrefix() {
     return "c_"; //$NON-NLS-1$
@@ -85,6 +97,14 @@ public class Util {
     return ( ch == '_' || ch == '$' );
   }
 
+  private static boolean isAcceptableUnicodeLetter( char ch ) {
+    Character.UnicodeBlock block = Character.UnicodeBlock.of( ch );
+    if ( !acceptableUnicodeBlocks.contains( block ) ) {
+      return false;
+    }
+    return true;
+  }
+
   /**
    * Returns <tt>true</tt> if <tt>code</tt> contains only latin characters, digits and '<tt>_</tt>' or '<tt>$</tt>'.
    * <tt>null</tt> or empty string is considered to be an invalid value.
@@ -99,7 +119,7 @@ public class Util {
 
     for ( int i = 0, len = id.length(); i < len; i++ ) {
       char ch = id.charAt( i );
-      if ( !isLatinLetter( ch ) && !isAsciiDigit( ch ) && !isAcceptableNonLetter( ch ) ) {
+      if ( !isLatinLetter( ch ) && !isAsciiDigit( ch ) && !isAcceptableNonLetter( ch ) && !isAcceptableUnicodeLetter( ch ) ) {
         return false;
       }
     }

--- a/test-src/org/pentaho/metadata/util/UtilTest.java
+++ b/test-src/org/pentaho/metadata/util/UtilTest.java
@@ -58,4 +58,9 @@ public class UtilTest {
   public void validateId_Empty() {
     assertFalse( Util.validateId( "" ) );
   }
+
+  @Test
+  public void validateId_Japanese() {
+    assertTrue( Util.validateId( "個人ID" ) );
+  }
 }

--- a/test-src/org/pentaho/metadata/util/UtilTest.java
+++ b/test-src/org/pentaho/metadata/util/UtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2016 Pentaho Corporation..  All rights reserved.
+ */
 package org.pentaho.metadata.util;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
- List of acceptable Unicode blocks is added to Util.validateId() method
- UTs for Japanese

**Important notices:**
1) Fix is implemented only for _Japanese_ symbols in Datasource's column names. Other countries' unicode characters (Russian, French, etc) still can cause the same issue. If we want this to be fixed for other counries-specific characters, I would like to have full list of countries to be able to add their blocks to acceptableUnicodeBlocks variable.
2) Fix can cause backward incompatibility of reports with Japanese symbols in Datasource's column names already created in 5.4 or larger, but resolve incompatibility between 5.1 and 5.4+.