### PR TITLE
[SP-2769] - Backport of PPP-3537 - Use of vulnerable component com.th…

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -10,7 +10,7 @@ dependency.libformula.group=pentaho-library
 dependency.libformula.revision=6.1-SNAPSHOT
 dependency.libbase.group=pentaho-library
 dependency.libbase.revision=6.1-SNAPSHOT
-dependency.xstream.revision=1.4.2
+dependency.xstream.revision=1.4.9
 dependency.mockito.revision=1.8.4
 
 dependency.pentaho-simple-jndi.revision=1.0.0

--- a/ivy.xml
+++ b/ivy.xml
@@ -37,7 +37,11 @@
     </dependency>
     <dependency org="pentaho" name="simple-jndi" rev="${dependency.pentaho-simple-jndi.revision}" />
     <!-- dependency org="jfree" name="jcommon" rev="1.0.14" / -->
-    <dependency org="com.thoughtworks.xstream" name="xstream" rev="${dependency.xstream.revision}" />
+
+    <!-- xstream with dependencies -->
+    <dependency org="xmlpull" name="xmlpull" rev="1.1.3.1" transitive="false"/>
+    <dependency org="xpp3" name="xpp3_min" rev="1.1.4c" transitive="false"/>
+    <dependency org="com.thoughtworks.xstream" name="xstream" rev="${dependency.xstream.revision}" transitive="false"/>
     
     <dependency org="org.apache.axis2" name="axis2-adb" rev="1.5" transitive="false"/>
     <dependency org="org.apache.axis2" name="axis2-kernel" rev="1.5" transitive="false"/>


### PR DESCRIPTION
…oughtworks.xstream v1.4.2 CVE-2013-7285 (6.1 Suite)

@pamval, here is backport of https://github.com/pentaho/pentaho-metadata/commit/1e8a25943dc58b52f1b1b341ed399689053df3ef to 6.1. Thanks. 