### PR TITLE
[SP-2768] Backport of BISERVER-13159 - Upgrade issue from 5.1 to 5.4 …

### DIFF
--- a/src/org/pentaho/metadata/util/Util.java
+++ b/src/org/pentaho/metadata/util/Util.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2009 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2016 Pentaho Corporation..  All rights reserved.
  */
 package org.pentaho.metadata.util;
 
@@ -28,6 +28,9 @@ import org.pentaho.metadata.model.concept.IConcept;
 import org.pentaho.pms.util.Settings;
 
 public class Util {
+
+  /** List of unacceptable characters which should corresponds to the regexp's inside the Util#toId method. */
+  public static final String MQL_RESERVED_CHARS = " .,:(){}[]\"`'*/+-";
 
   public static final String CR = System.getProperty( "line.separator" ); //$NON-NLS-1$
 
@@ -72,19 +75,6 @@ public class Util {
     return name;
   }
 
-  private static boolean isLatinLetter( char ch ) {
-    return ( ( 'a' <= ch ) && ( ch <= 'z' ) ) ||
-      ( ( 'A' <= ch ) && ( ch <= 'Z' ) );
-  }
-
-  private static boolean isAsciiDigit( char ch ) {
-    return ( '0' <= ch ) && ( ch <= '9' );
-  }
-
-  private static boolean isAcceptableNonLetter( char ch ) {
-    return ( ch == '_' || ch == '$' );
-  }
-
   /**
    * Returns <tt>true</tt> if <tt>code</tt> contains only latin characters, digits and '<tt>_</tt>' or '<tt>$</tt>'.
    * <tt>null</tt> or empty string is considered to be an invalid value.
@@ -99,12 +89,22 @@ public class Util {
 
     for ( int i = 0, len = id.length(); i < len; i++ ) {
       char ch = id.charAt( i );
-      if ( !isLatinLetter( ch ) && !isAsciiDigit( ch ) && !isAcceptableNonLetter( ch ) ) {
+      if ( isUnacceptableCharacter( ch ) ) {
         return false;
       }
     }
 
     return true;
+  }
+
+  /**
+   * Check if character is unacceptable for MQL and need to be converted.
+   *
+   * @param ch character to check
+   * @return true if character is unacceptable for MQL, false otherwise
+   */
+  private static boolean isUnacceptableCharacter( char ch ) {
+    return MQL_RESERVED_CHARS.indexOf( ch ) != -1;
   }
 
   public static IllegalArgumentException idValidationFailed( String id ) {

--- a/test-src/org/pentaho/metadata/util/UtilTest.java
+++ b/test-src/org/pentaho/metadata/util/UtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2016 Pentaho Corporation..  All rights reserved.
+ */
 package org.pentaho.metadata.util;
 
 import static org.junit.Assert.assertEquals;
@@ -39,6 +55,9 @@ public class UtilTest {
     assertTrue( Util.validateId( "qwerty_1" ) );
     assertTrue( Util.validateId( "qwerty_$1" ) );
     assertTrue( Util.validateId( "qWerTy_$1" ) );
+    assertTrue( Util.validateId( "Кириллические_символы" ) );
+    assertTrue( Util.validateId( "日本の手紙" ) );
+    assertTrue( Util.validateId( "caractères_français" ) );
   }
 
   @Test


### PR DESCRIPTION
[SP-2768] Backport of BISERVER-13159 - Upgrade issue from 5.1 to 5.4 when SQL datasource created via Data Access Wizard has Japanese Columns in it. (6.1 Suite)