### PR TITLE
[SP-2767] - Backport of BISERVER-13159 - Upgrade issue from 5.1 to 5.…

### DIFF
--- a/src/org/pentaho/metadata/util/Util.java
+++ b/src/org/pentaho/metadata/util/Util.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2009 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2016 Pentaho Corporation..  All rights reserved.
  */
 package org.pentaho.metadata.util;
 
@@ -28,6 +28,9 @@ import org.pentaho.metadata.model.concept.IConcept;
 import org.pentaho.pms.util.Settings;
 
 public class Util {
+
+  /** List of unacceptable characters which should corresponds to the regexp's inside the Util#toId method. */
+  public static final String MQL_RESERVED_CHARS = " .,:(){}[]\"`'*/+-";
 
   public static final String CR = System.getProperty( "line.separator" ); //$NON-NLS-1$
 
@@ -72,19 +75,6 @@ public class Util {
     return name;
   }
 
-  private static boolean isLatinLetter( char ch ) {
-    return ( ( 'a' <= ch ) && ( ch <= 'z' ) ) ||
-      ( ( 'A' <= ch ) && ( ch <= 'Z' ) );
-  }
-
-  private static boolean isAsciiDigit( char ch ) {
-    return ( '0' <= ch ) && ( ch <= '9' );
-  }
-
-  private static boolean isAcceptableNonLetter( char ch ) {
-    return ( ch == '_' || ch == '$' );
-  }
-
   /**
    * Returns <tt>true</tt> if <tt>code</tt> contains only latin characters, digits and '<tt>_</tt>' or '<tt>$</tt>'.
    * <tt>null</tt> or empty string is considered to be an invalid value.
@@ -99,12 +89,22 @@ public class Util {
 
     for ( int i = 0, len = id.length(); i < len; i++ ) {
       char ch = id.charAt( i );
-      if ( !isLatinLetter( ch ) && !isAsciiDigit( ch ) && !isAcceptableNonLetter( ch ) ) {
+      if ( isUnacceptableCharacter( ch ) ) {
         return false;
       }
     }
 
     return true;
+  }
+
+  /**
+   * Check if character is unacceptable for MQL and need to be converted.
+   *
+   * @param ch character to check
+   * @return true if character is unacceptable for MQL, false otherwise
+   */
+  private static boolean isUnacceptableCharacter( char ch ) {
+    return MQL_RESERVED_CHARS.indexOf( ch ) != -1;
   }
 
   public static IllegalArgumentException idValidationFailed( String id ) {

--- a/test/org/pentaho/helpers/SQLDialectHelper.java
+++ b/test/org/pentaho/helpers/SQLDialectHelper.java
@@ -1,0 +1,98 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2016 Pentaho Corporation..  All rights reserved.
+ */
+package org.pentaho.helpers;
+
+import org.pentaho.pms.mql.dialect.SQLDialectInterface;
+import org.pentaho.pms.mql.dialect.SQLQueryModel;
+import org.pentaho.pms.mql.dialect.SQLQueryModel.OrderType;
+
+import static org.junit.Assert.assertEquals;
+
+public class SQLDialectHelper {
+
+  public static void assertEqualsIgnoreWhitespaces( String expected, String two ) {
+    String oneStripped = stripWhiteSpaces( expected );
+    String twoStripped = stripWhiteSpaces( two );
+
+    assertEquals( oneStripped, twoStripped );
+  }
+
+  public static void assertEqualsIgnoreWhitespacesAndCase( String expected, String actual ) {
+    assertEqualsIgnoreWhitespaces( expected.toUpperCase(), actual.toUpperCase() );
+  }
+
+  private static String stripWhiteSpaces( String one ) {
+    StringBuilder stripped = new StringBuilder();
+
+    boolean previousWhiteSpace = false;
+
+    for ( char c : one.toCharArray() ) {
+      if ( Character.isWhitespace( c ) ) {
+        if ( !previousWhiteSpace ) {
+          stripped.append( ' ' ); // add a single white space, don't add a second
+        }
+        previousWhiteSpace = true;
+      } else {
+        if ( c == '(' || c == ')' || c == '|' || c == '-' || c == '+' || c == '/' || c == '*' || c == '{' || c == '}'
+            || c == ',' ) {
+          int lastIndex = stripped.length() - 1;
+          if ( stripped.charAt( lastIndex ) == ' ' ) {
+            stripped.deleteCharAt( lastIndex );
+          }
+          previousWhiteSpace = true;
+        } else {
+          previousWhiteSpace = false;
+        }
+        stripped.append( c );
+      }
+    }
+
+    // Trim the whitespace (max 1) at the front and back too...
+    if ( stripped.length() > 0 && Character.isWhitespace( stripped.charAt( 0 ) ) ) {
+      stripped.deleteCharAt( 0 );
+    }
+    if ( stripped.length() > 0 && Character.isWhitespace( stripped.charAt( stripped.length() - 1 ) ) ) {
+      stripped.deleteCharAt( stripped.length() - 1 );
+    }
+
+    return stripped.toString();
+  }
+
+  public static SQLQueryModel createLimitedQuery() {
+    SQLQueryModel query = new SQLQueryModel();
+    query.addSelection( "t.id", null ); //$NON-NLS-1$
+    query.addTable( "TABLE", "t" ); //$NON-NLS-1$ //$NON-NLS-2$
+    query.addWhereFormula( "t.id is null", null ); //$NON-NLS-1$
+    query.setLimit( 10 );
+    query.addOrderBy( null, "t.id", OrderType.ASCENDING );
+    return query;
+  }
+
+  public static SQLQueryModel createUnlimitedQuery() {
+    SQLQueryModel query = new SQLQueryModel();
+    query.addSelection( "t.id", null ); //$NON-NLS-1$
+    query.addTable( "TABLE", "t" ); //$NON-NLS-1$ //$NON-NLS-2$
+    query.addWhereFormula( "t.id is null", null ); //$NON-NLS-1$
+    query.addOrderBy( null, "t.id", OrderType.ASCENDING );
+    return query;
+  }
+
+  public static void assertSelect( String expected, SQLDialectInterface dialect, SQLQueryModel query ) {
+    String result = dialect.generateSelectStatement( query );
+    assertEqualsIgnoreWhitespacesAndCase( expected, result );
+  }
+}

--- a/test/org/pentaho/metadata/util/UtilTest.java
+++ b/test/org/pentaho/metadata/util/UtilTest.java
@@ -1,13 +1,29 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2016 Pentaho Corporation..  All rights reserved.
+ */
 package org.pentaho.metadata.util;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class UtilTest {
 
@@ -39,6 +55,9 @@ public class UtilTest {
     assertTrue( Util.validateId( "qwerty_1" ) );
     assertTrue( Util.validateId( "qwerty_$1" ) );
     assertTrue( Util.validateId( "qWerTy_$1" ) );
+    assertTrue( Util.validateId( "Кириллические_символы" ) );
+    assertTrue( Util.validateId( "日本の手紙" ) );
+    assertTrue( Util.validateId( "caractères_français" ) );
   }
 
   @Test

--- a/test/org/pentaho/pms/MQLQueryTest.java
+++ b/test/org/pentaho/pms/MQLQueryTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2006 - 2009 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2006 - 2016 Pentaho Corporation..  All rights reserved.
  */
 package org.pentaho.pms;
 
@@ -738,12 +738,12 @@ public class MQLQueryTest extends TestCase {
       String data = new String( bytes, Const.XML_ENCODING );
       // remove the <?xml version="1.0" encoding="UTF-8"?>, it appears differently in different JVM versions
       data = data.replaceAll( "<\\?.*\\?>", "" ); //$NON-NLS-1$ //$NON-NLS-2$
-      data = data.replaceAll( "[\n\t]", "" ); //$NON-NLS-1$ //$NON-NLS-2$
+      data = data.replaceAll( "[\r\n\t]", "" ); //$NON-NLS-1$ //$NON-NLS-2$
       String xml = mqlquery.getXML();
       assertNotNull( xml );
       // remove the <?xml version="1.0" encoding="UTF-8"?>, it appears differently in different JVM versions
       xml = xml.replaceAll( "<\\?.*\\?>", "" ); //$NON-NLS-1$ //$NON-NLS-2$
-      xml = xml.replaceAll( "[\n\t]", "" ); //$NON-NLS-1$ //$NON-NLS-2$
+      xml = xml.replaceAll( "[\r\n\t]", "" ); //$NON-NLS-1$ //$NON-NLS-2$
       xml = xml.replaceAll( "<limit>-1</limit>", "" );
       /*
        * System.out.println("Generated XML"); System.out.println(xml); System.out.println("File XML");

--- a/test/org/pentaho/pms/mql/dialect/HiveDialectTest.java
+++ b/test/org/pentaho/pms/mql/dialect/HiveDialectTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 20011 Pentaho Corporation.  All rights reserved.
+ * Copyright (c) 2016 Pentaho Corporation.  All rights reserved.
  */
 package org.pentaho.pms.mql.dialect;
 
@@ -28,9 +28,8 @@ import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.varia.NullAppender;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.pentaho.di.core.database.DatabaseInterface;
-import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.helpers.SQLDialectHelper;
 import org.pentaho.pms.MetadataTestBase;
 import org.pentaho.pms.mql.dialect.SQLQueryModel.OrderType;
 
@@ -86,7 +85,7 @@ public class HiveDialectTest {
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
 
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -101,7 +100,7 @@ public class HiveDialectTest {
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
 
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -116,7 +115,7 @@ public class HiveDialectTest {
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
 
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -130,7 +129,7 @@ public class HiveDialectTest {
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
 
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -146,7 +145,7 @@ public class HiveDialectTest {
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
 
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -171,7 +170,7 @@ public class HiveDialectTest {
     String expected = "SELECT DISTINCT \n          id\nFROM \n          A\n          JOIN B ON ( A.b = B.id )\n"; //$NON-NLS-1$
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -183,7 +182,7 @@ public class HiveDialectTest {
         "SELECT DISTINCT \n          id\nFROM \n          A\n          JOIN B\nWHERE\n          ( A.b > B.id )\n"; //$NON-NLS-1$
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -196,7 +195,7 @@ public class HiveDialectTest {
         "SELECT DISTINCT \n          id\nFROM \n          A\n          JOIN B ON ( A.b = B.id )\n          JOIN C ON ( B.c = C.id )\n"; //$NON-NLS-1$
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -209,7 +208,7 @@ public class HiveDialectTest {
         "SELECT DISTINCT \n          id\nFROM \n          A\n          JOIN B\n          JOIN C\nWHERE\n          ( A.b > B.id )\n      AND ( B.c > C.id )\n"; //$NON-NLS-1$
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -222,7 +221,7 @@ public class HiveDialectTest {
         "SELECT DISTINCT \n          id\nFROM \n          B\n          JOIN C ON ( B.c = C.id )\n          JOIN A ON ( A.b = B.id )\n"; //$NON-NLS-1$
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -235,7 +234,7 @@ public class HiveDialectTest {
         "SELECT DISTINCT \n          id\nFROM \n          B\n          JOIN C\n          JOIN A ON ( A.b = B.id )\nWHERE\n          ( B.c > C.id )\n"; //$NON-NLS-1$
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -249,7 +248,7 @@ public class HiveDialectTest {
         "SELECT DISTINCT \n          id\nFROM \n          A\n          JOIN B ON ( A.b = B.id )\n          JOIN C ON ( B.c = C.id )\n          JOIN D ON ( C.d = D.id )\n"; //$NON-NLS-1$
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -263,7 +262,7 @@ public class HiveDialectTest {
         "SELECT DISTINCT \n          id\nFROM \n          A\n          JOIN B ON ( A.b = B.id )\n          JOIN C\n          JOIN D ON ( C.d = D.id )\nWHERE\n          ( B.c > C.id )\n"; //$NON-NLS-1$
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -277,7 +276,7 @@ public class HiveDialectTest {
         "SELECT DISTINCT \n          id\nFROM \n          C\n          JOIN D ON ( C.d = D.id )\n          JOIN B\n          JOIN A ON ( A.b = B.id )\nWHERE\n          ( B.c > C.id )\n"; //$NON-NLS-1$
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -338,7 +337,7 @@ public class HiveDialectTest {
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
 
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -358,7 +357,7 @@ public class HiveDialectTest {
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
 
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -382,7 +381,7 @@ public class HiveDialectTest {
     };
     String result = dialect.generateSelectStatement( query );
 
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -401,7 +400,7 @@ public class HiveDialectTest {
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
 
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -423,7 +422,7 @@ public class HiveDialectTest {
     String formula = "a.id"; //$NON-NLS-1$
     String expected = "id"; //$NON-NLS-1$
     String result = new HiveDialect().stripTableAliasesFromFormula( formula );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -438,7 +437,7 @@ public class HiveDialectTest {
     String formula = "count(a.id)"; //$NON-NLS-1$
     String expected = "count(id)"; //$NON-NLS-1$
     String result = new HiveDialect().stripTableAliasesFromFormula( formula );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -446,7 +445,7 @@ public class HiveDialectTest {
     String formula = "count( a .id)"; //$NON-NLS-1$
     String expected = "count( id)"; //$NON-NLS-1$
     String result = new HiveDialect().stripTableAliasesFromFormula( formula );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -459,7 +458,7 @@ public class HiveDialectTest {
         "SELECT DISTINCT \n          id\nFROM \n          TABLE t\nWHERE \n        (\n          (\n             name <> 'test'\n          )\n        )\n"; //$NON-NLS-1$
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -473,7 +472,7 @@ public class HiveDialectTest {
         "SELECT DISTINCT \n          id\nFROM \n          TABLE t\nWHERE \n        (\n          (\n             name <> 'test'\n          )\n      AND (\n             age = 10\n          )\n        )\n"; //$NON-NLS-1$
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -487,7 +486,7 @@ public class HiveDialectTest {
         "SELECT DISTINCT \n          id\nFROM \n          TABLE2 two\n          JOIN TABLE t\nWHERE\n          ( two.id > t.id )\n      AND \n        (\n          (\n             name <> 'test'\n          )\n        )\n"; //$NON-NLS-1$
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -500,7 +499,7 @@ public class HiveDialectTest {
         "SELECT DISTINCT \n          t.WHERES_WALDO\nFROM \n          TABLE t\nWHERE \n        (\n          (\n             name <> 'test'\n          )\n        )\n"; //$NON-NLS-1$
     SQLDialectInterface dialect = new HiveDialect();
     String result = dialect.generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
 
   }
 
@@ -510,7 +509,7 @@ public class HiveDialectTest {
     String expected = "CONCAT('string')"; //$NON-NLS-1$
     HiveDialect dialect = new HiveDialect();
     String result = dialect.generateStringConcat( vals );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -519,7 +518,7 @@ public class HiveDialectTest {
     String expected = "CONCAT('%',value,'%')"; //$NON-NLS-1$
     HiveDialect dialect = new HiveDialect();
     String result = dialect.generateStringConcat( vals );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   /**
@@ -558,7 +557,7 @@ public class HiveDialectTest {
     String expected =
         "SELECT DISTINCT \n          a.a_column\nFROM \n          A a\nORDER BY \n          a_column ASC\n\nLIMIT 10\n";
     String result = new HiveDialect().generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test
@@ -570,7 +569,7 @@ public class HiveDialectTest {
     String expected =
         "SELECT DISTINCT \n          a.a_column\nFROM \n          A a\nORDER BY \n          a_column ASC\n";
     String result = new HiveDialect().generateSelectStatement( query );
-    assertEquals( expected, result );
+    SQLDialectHelper.assertEqualsIgnoreWhitespaces( expected, result );
   }
 
   @Test


### PR DESCRIPTION
…4 when SQL datasource created via Data Access Wizard has Japanese Columns in it. (5.4 Suite)

- List of unacceptable characters was added for validateId() method
- UTs
- MQL_RESERVED_CHARS constant was added
- Updated the Headers

@pamval, could you please take a look?  
*as far as I know static imports should be allowed in this context.