### PR TITLE
[SP-2981] Backport of PMD-993 - Field precision in Interactive Reports does not use precision set in Metadata model (6.1 Suite)

### DIFF
--- a/src/org/pentaho/metadata/util/XmiParser.java
+++ b/src/org/pentaho/metadata/util/XmiParser.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2009 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2009 - 2016 Pentaho Corporation..  All rights reserved.
  */
 package org.pentaho.metadata.util;
 
@@ -1594,6 +1594,13 @@ public class XmiParser {
             // <CWM:Description body="String,50,-1" name="datatype" type="DataType" xmi.id="a100">
             DataTypeSettings setting = DataTypeSettings.fromString( body );
             concept.setProperty( name, DataType.valueOf( setting.getCode().toUpperCase() ) );
+            if ( setting.getPrecision() > 0 ) {
+              String mask = "#.";
+              for ( int i = 0; i < setting.getPrecision(); i++ ) {
+                mask += "0";
+              }
+              concept.setProperty( "mask", mask );
+            }
           } else if ( propType.equals( "Security" ) ) { //$NON-NLS-1$
             // <CWM:Description
             // body="&lt;security&gt;&#10;  &lt;owner-rights&gt;&#10;  &lt;owner&gt;&lt;type&gt;user&lt;/type&gt;&lt;name&gt;suzy&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#10;  &lt;/owner-rights&gt;&#10;  &lt;owner-rights&gt;&#10;  &lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;Admin&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#10;  &lt;/owner-rights&gt;&#10;&lt;/security&gt;&#10;"

--- a/src/org/pentaho/pms/schema/concept/types/datatype/ConceptPropertyDataType.java
+++ b/src/org/pentaho/pms/schema/concept/types/datatype/ConceptPropertyDataType.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2006 - 2009 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2006 - 2016 Pentaho Corporation..  All rights reserved.
  */
 package org.pentaho.pms.schema.concept.types.datatype;
 
@@ -58,7 +58,7 @@ public class ConceptPropertyDataType extends ConceptPropertyBase implements Clon
   public Object clone() throws CloneNotSupportedException {
     ConceptPropertyDataType rtn = (ConceptPropertyDataType) super.clone();
     if ( value != null ) {
-      rtn.value = new DataTypeSettings( value.getType() );
+      rtn.value = new DataTypeSettings( value.getType(), value.getLength(), value.getPrecision() );
     }
     return rtn;
   }


### PR DESCRIPTION
backport of #112