### PR TITLE
[BISERVER-13522]-Migrated or Imported Interactive reports do not run due to missing XMI extension

### DIFF
--- a/src/main/java/org/pentaho/metadata/query/model/util/QueryXmlHelper.java
+++ b/src/main/java/org/pentaho/metadata/query/model/util/QueryXmlHelper.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2009 - 2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2009 - 2017 Pentaho Corporation..  All rights reserved.
  */
 package org.pentaho.metadata.query.model.util;
 
@@ -341,7 +341,19 @@ public class QueryXmlHelper {
     String domainId = getElementText( doc, "domain_id" ); //$NON-NLS-1$
     Domain domain = repo.getDomain( domainId );
     if ( domain == null ) {
+      if ( domainId != null && !domainId.contains( ".xmi" ) ) {
+        domain = repo.getDomain( domainId + ".xmi" );
+      }
+      if ( domain != null ) {
+        logger.warn( String.format( "Metadata model [%1$s] was requested, but the model doesn't exist. "
+            + "Substituting [%1$s.xmi] instead as a legacy fallback. "
+            + "Please change your reports to reference %1$s.xmi instead", domainId ) );
+      }
+    }
+    if ( domain == null ) {
       // need to throw an error
+      logger.error( String.format( "Metadata model [%1$s] doesn't exist. "
+          + "Please check the existence of the model", domainId ) );
       throw new PentahoMetadataException( Messages.getErrorString(
           "QueryXmlHelper.ERROR_0009_DOMAIN_INSTANCE_NULL", domainId ) ); //$NON-NLS-1$
     }

--- a/src/test/java/org/pentaho/metadata/query/model/util/QueryXmlHelperTest.java
+++ b/src/test/java/org/pentaho/metadata/query/model/util/QueryXmlHelperTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright 2005 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2005 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.metadata.query.model.util;
@@ -219,6 +219,22 @@ public class QueryXmlHelperTest {
     xml = helper.toXML( query );
     xml = xml.replaceAll( "<limit>\\s*123\\s*</limit>", "<limit>abc</limit>" );
 
+    try {
+      query = helper.fromXML( metadataDomainRepository, xml );
+      fail();
+    } catch ( PentahoMetadataException e ) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testFromXML() throws Exception {
+    Domain domain = TestHelper.getBasicDomain();
+    LogicalModel model = TestHelper.buildDefaultModel();
+    domain.addLogicalModel( model );
+    model.setId( "MODEL2" );
+    Query query = new Query( domain, model );
+    String xml = helper.toXML( query );
     try {
       query = helper.fromXML( metadataDomainRepository, xml );
       fail();


### PR DESCRIPTION
 - try a second time to obtain a domain by adding ".xmi" in the name
 - added unittest