### PR TITLE
[BACKLOG-19149] Fixes content endpoint authentication code; originall…

### DIFF
--- a/src/main/java/org/pentaho/pms/schema/security/SecurityService.java
+++ b/src/main/java/org/pentaho/pms/schema/security/SecurityService.java
@@ -313,14 +313,14 @@ public class SecurityService extends ChangedFlag implements Cloneable {
       // client.getState().setProxyCredentials(AuthScope.ANY,
       // new UsernamePasswordCredentials(username, password != null ? password : new String()));
       // }
+    }
 
-      // If server userid/password was supplied, use basic authentication to
-      // authenticate with the server.
-      if ( StringUtils.isNotBlank( username ) && StringUtils.isNotBlank( password )  ) {
-        AuthScope authScope = new AuthScope( tempURL.getHost(), tempURL.getPort() );
-        httpClientBuilder.setCredentials( username, password, authScope );
-        HttpClientUtil.createPreemptiveBasicAuthentication( proxyHostname, port, username, password );
-      }
+    // If server userid/password was supplied, use basic authentication to
+    // authenticate with the server.
+    if ( StringUtils.isNotBlank( username ) && StringUtils.isNotBlank( password )  ) {
+      AuthScope authScope = new AuthScope( tempURL.getHost(), tempURL.getPort() );
+      httpClientBuilder.setCredentials( username, password, authScope );
+      context = HttpClientUtil.createPreemptiveBasicAuthentication( tempURL.getHost(), tempURL.getPort(), username, password );
     }
 
     HttpClient client = httpClientBuilder.build();


### PR DESCRIPTION
…y changed when httpclient version upgraded

@pentaho/rogueone @pentaho/rebelalliance Please review

There was a changed made on Aug 3rd (https://github.com/pentaho/pentaho-metadata/commit/c1c1a5127adee52ff3830ce26c2aa54926e3f8a3) to upgrade the httpclient artifact. Some code changes were made to conform with the new version. The authentication block got moved inside of the proxy check code and I'm not sure it was supposed to be. As a result, the endpoint call was not authenticated and returned the HTML page for Pentaho login instead of the security list. Since the code didn't know how to interpret that returned HTML, it displayed nothing instead. This moves the authentication outside of the proxy block so it authenticates the call and returns the correct security list.