### PR TITLE
[ANALYZER-3559]-When filtering the date field (format YYYY-MM-DD HH:MM:SS.0) it shows "The report has no data"

### DIFF
--- a/src/main/java/org/pentaho/metadata/automodel/PhysicalTableImporter.java
+++ b/src/main/java/org/pentaho/metadata/automodel/PhysicalTableImporter.java
@@ -158,8 +158,9 @@ public class PhysicalTableImporter {
         return DataType.BINARY;
       case ValueMetaInterface.TYPE_BOOLEAN:
         return DataType.BOOLEAN;
-      case ValueMetaInterface.TYPE_DATE:
       case ValueMetaInterface.TYPE_TIMESTAMP:
+        return DataType.TIMESTAMP;
+      case ValueMetaInterface.TYPE_DATE:
         return DataType.DATE;
       case ValueMetaInterface.TYPE_STRING:
         return DataType.STRING;

--- a/src/main/java/org/pentaho/metadata/model/concept/types/DataType.java
+++ b/src/main/java/org/pentaho/metadata/model/concept/types/DataType.java
@@ -27,7 +27,8 @@ package org.pentaho.metadata.model.concept.types;
  * <li> {@link #BINARY}
  * <li> {@link #IMAGE}
  * <li> {@link #URL}
- * 
+ * <li> {@link #TIMESTAMP}
+ *
  * @author Will Gorman (wgorman@pentaho.com)
  * 
  */
@@ -39,7 +40,8 @@ public enum DataType {
   NUMERIC( 4, "Numeric", "DataType.USER_NUMERIC_DESC" ), //$NON-NLS-1$  //$NON-NLS-2$
   BINARY( 5, "Binary", "DataType.USER_BINARY_DESC" ), //$NON-NLS-1$  //$NON-NLS-2$
   IMAGE( 6, "Image", "DataType.USER_IMAGE_DESC" ), //$NON-NLS-1$  //$NON-NLS-2$
-  URL( 7, "URL", "DataType.USER_URL_DESC" ); //$NON-NLS-1$  //$NON-NLS-2$
+  URL( 7, "URL", "DataType.USER_URL_DESC" ), //$NON-NLS-1$  //$NON-NLS-2$
+  TIMESTAMP( 8, "Timestamp", "DataType.USER_TIMESTAMP_DESC" ); //$NON-NLS-1$  //$NON-NLS-2$
 
   private int type;
   private String name, description;

--- a/src/main/java/org/pentaho/pms/schema/concept/types/datatype/ConceptPropertyDataType.java
+++ b/src/main/java/org/pentaho/pms/schema/concept/types/datatype/ConceptPropertyDataType.java
@@ -36,6 +36,7 @@ public class ConceptPropertyDataType extends ConceptPropertyBase implements Clon
       new ConceptPropertyDataType( "datatype", DataTypeSettings.BINARY ); //$NON-NLS-1$
   public static final ConceptPropertyDataType IMAGE = new ConceptPropertyDataType( "datatype", DataTypeSettings.IMAGE ); //$NON-NLS-1$
   public static final ConceptPropertyDataType URL = new ConceptPropertyDataType( "datatype", DataTypeSettings.URL ); //$NON-NLS-1$
+  public static final ConceptPropertyDataType TIMESTAMP = new ConceptPropertyDataType( "datatype", DataTypeSettings.TIMESTAMP ); //$NON-NLS-1$
 
   private DataTypeSettings value;
 

--- a/src/main/java/org/pentaho/pms/schema/concept/types/datatype/DataTypeSettings.java
+++ b/src/main/java/org/pentaho/pms/schema/concept/types/datatype/DataTypeSettings.java
@@ -32,6 +32,7 @@ public class DataTypeSettings {
   public static final int DATA_TYPE_BINARY = 5;
   public static final int DATA_TYPE_IMAGE = 6;
   public static final int DATA_TYPE_URL = 7;
+  public static final int DATA_TYPE_TIMESTAMP = 8;
 
   public static final DataTypeSettings UNKNOWN = new DataTypeSettings( DATA_TYPE_UNKNOWN );
   public static final DataTypeSettings STRING = new DataTypeSettings( DATA_TYPE_STRING );
@@ -41,9 +42,10 @@ public class DataTypeSettings {
   public static final DataTypeSettings BINARY = new DataTypeSettings( DATA_TYPE_BINARY );
   public static final DataTypeSettings IMAGE = new DataTypeSettings( DATA_TYPE_IMAGE );
   public static final DataTypeSettings URL = new DataTypeSettings( DATA_TYPE_URL );
+  public static final DataTypeSettings TIMESTAMP = new DataTypeSettings( DATA_TYPE_TIMESTAMP );
 
   private static final String[] typeCodes = {
-    "Unknown", "String", "Date", "Boolean", "Numeric", "Binary", "Image", "URL", }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$
+    "Unknown", "String", "Date", "Boolean", "Numeric", "Binary", "Image", "URL", "Timestamp", }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$
   private static final String[] typeDescriptions = { Messages.getString( "DataTypeSettings.USER_UNKNOWN_DESC" ), //$NON-NLS-1$
     Messages.getString( "DataTypeSettings.USER_STRING_DESC" ), //$NON-NLS-1$
     Messages.getString( "DataTypeSettings.USER_DATE_DESC" ), //$NON-NLS-1$
@@ -51,9 +53,10 @@ public class DataTypeSettings {
     Messages.getString( "DataTypeSettings.USER_NUMERIC_DESC" ), //$NON-NLS-1$
     Messages.getString( "DataTypeSettings.USER_BINARY_DESC" ), //$NON-NLS-1$
     Messages.getString( "DataTypeSettings.USER_IMAGE_DESC" ), //$NON-NLS-1$
-    Messages.getString( "DataTypeSettings.USER_URL_DESC" ), }; //$NON-NLS-1$
+    Messages.getString( "DataTypeSettings.USER_URL_DESC" ), //$NON-NLS-1$
+    Messages.getString( "DataTypeSettings.USER_TIMESTAMP_DESC" ), }; //$NON-NLS-1$
   public static final DataTypeSettings[] types = new DataTypeSettings[] { UNKNOWN, STRING, DATE, BOOLEAN, NUMERIC,
-    BINARY, IMAGE, URL, };
+    BINARY, IMAGE, URL, TIMESTAMP, };
 
   private static final String SEPARATOR = ","; //$NON-NLS-1$
 

--- a/src/main/resources/org/pentaho/pms/locale/messages.properties
+++ b/src/main/resources/org/pentaho/pms/locale/messages.properties
@@ -215,6 +215,7 @@ DataTypeSettings.USER_NUMERIC_DESC=Numeric
 DataTypeSettings.USER_STRING_DESC=String
 DataTypeSettings.USER_UNKNOWN_DESC=Unknown
 DataTypeSettings.USER_URL_DESC=URL
+DataTypeSettings.USER_TIMESTAMP_DESC=Timestamp
 DefaultPropertyID.USER_AGGREGATION_RULE_DESC=Default Aggregation 
 DefaultPropertyID.USER_AGGREGATION_LIST_DESC=Optional Aggregations
 DefaultPropertyID.USER_BACKGROUND_COLOR_DESC=Color of Background

--- a/src/test/java/org/pentaho/metadata/automodel/PhysicalTableImporterTest.java
+++ b/src/test/java/org/pentaho/metadata/automodel/PhysicalTableImporterTest.java
@@ -102,7 +102,7 @@ public class PhysicalTableImporterTest {
 
     IPhysicalColumn column = physicalColumns.get( 0 );
     DataType dt = ( DataType ) column.getProperty( "datatype" );
-    assertEquals( "Date", dt.getName() );
+    assertEquals( "Timestamp", dt.getName() );
   }
 
   @Test


### PR DESCRIPTION
Should be merged first https://github.com/pentaho/pentaho-metadata/pull/180
second https://github.com/pentaho/pentaho-kettle/pull/4681
then https://github.com/pentaho/data-access/pull/971 
and https://github.com/pentaho/pentaho-data-refinery/pull/103