### PR TITLE
[BACKLOG-27345] - upgrading joda-time to the latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,13 +37,14 @@
     <pentaho-cwm.version>1.5.4</pentaho-cwm.version>
     <netbeans.version>200507110943</netbeans.version>
     <netbeans-custom.version>200507110943-custom</netbeans-custom.version>
+    <joda-time.version>2.10.2</joda-time.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>1.6</version>
+      <version>${joda-time.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>


### PR DESCRIPTION
aws-java-sdk-core depends on verstion later than 1.6