### PR TITLE
[BACKLOG-43902]-Java 21 : compatibility check for Pentaho and fix Build and Run time issues while building / testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,13 +170,13 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy-agent</artifactId>
-      <version>1.12.16</version>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.12.16</version>
+      <version>${byte-buddy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This pull request makes a minor update to the `pom.xml` file. It replaces hardcoded versions of the `byte-buddy` and `byte-buddy-agent` test dependencies with the `${byte-buddy.version}` property, making version management more flexible.