### PR TITLE
test[BACKLOG-43752]: stabilize metadata integration tests

### DIFF
--- a/src/it/java/org/pentaho/metadata/SqlOpenFormulaIT.java
+++ b/src/it/java/org/pentaho/metadata/SqlOpenFormulaIT.java
@@ -106,9 +106,9 @@ public class SqlOpenFormulaIT {
 
   @AfterClass
   public static void deleteFiles() throws Exception {
-        if ( CWM.exists( "Orders" ) ) { //$NON-NLS-1$
-            CWM.getInstance( "Orders", false ).removeDomain(); //$NON-NLS-1$
-        }
+    if ( CWM.exists( "Orders" ) ) { //$NON-NLS-1$
+      CWM.getInstance( "Orders", false ).removeDomain(); //$NON-NLS-1$
+    }
     deleteFile( "mdr.btb" );
     deleteFile( "mdr.btd" );
     deleteFile( "mdr.btx" );

--- a/src/it/java/org/pentaho/metadata/SqlOpenFormulaIT.java
+++ b/src/it/java/org/pentaho/metadata/SqlOpenFormulaIT.java
@@ -106,6 +106,9 @@ public class SqlOpenFormulaIT {
 
   @AfterClass
   public static void deleteFiles() throws Exception {
+        if ( CWM.exists( "Orders" ) ) { //$NON-NLS-1$
+            CWM.getInstance( "Orders", false ).removeDomain(); //$NON-NLS-1$
+        }
     deleteFile( "mdr.btb" );
     deleteFile( "mdr.btd" );
     deleteFile( "mdr.btx" );

--- a/src/it/java/org/pentaho/metadata/ThinModelIT.java
+++ b/src/it/java/org/pentaho/metadata/ThinModelIT.java
@@ -14,6 +14,7 @@
 package org.pentaho.metadata;
 
 import org.junit.Assert;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.metadata.model.Category;
@@ -63,9 +64,24 @@ import static org.junit.Assert.fail;
 @SuppressWarnings( "deprecation" )
 public class ThinModelIT {
 
+  private static final String ORDERS_DOMAIN = "Orders";
+  private static final String STEEL_WHEELS_DOMAIN = "SteelWheels";
+
   @BeforeClass
   public static void initKettle() throws Exception {
     MetadataTestBase.initKettleEnvironment();
+  }
+
+  @After
+  public void removeLegacyDomains() throws Exception {
+    removeDomain( ORDERS_DOMAIN );
+    removeDomain( STEEL_WHEELS_DOMAIN );
+  }
+
+  private void removeDomain( String domainName ) throws Exception {
+    if ( CWM.exists( domainName ) ) {
+      CWM.getInstance( domainName, false ).removeDomain();
+    }
   }
 
   @Test

--- a/src/it/java/org/pentaho/pms/MQLQueryIT.java
+++ b/src/it/java/org/pentaho/pms/MQLQueryIT.java
@@ -26,6 +26,7 @@ import org.mockito.Mockito;
 import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.pms.core.CWM;
+import org.pentaho.pms.core.exception.CWMException;
 import org.pentaho.pms.core.exception.PentahoMetadataException;
 import org.pentaho.pms.factory.CwmSchemaFactory;
 import org.pentaho.pms.factory.CwmSchemaFactoryInterface;
@@ -47,22 +48,29 @@ import org.pentaho.pms.schema.concept.types.aggregation.AggregationSettings;
 @SuppressWarnings( { "deprecation", "nls" } )
 public class MQLQueryIT extends TestCase {
 
+  private static final String TEST_DOMAIN = "Orders";
+
   BusinessModel ordersModel = null;
 
   CwmSchemaFactory cwmSchemaFactory = null;
 
+  CWM cwm = null;
+
   public void setUp() throws Exception {
     MetadataTestBase.initKettleEnvironment();
-    if ( ordersModel == null || cwmSchemaFactory == null ) {
-      loadOrdersModel();
-    }
+    removeTestDomain();
+    loadOrdersModel();
   }
 
   @Override
   protected void tearDown() throws Exception {
-    deleteFile( "mdr.btb" );
-    deleteFile( "mdr.btd" );
-    deleteFile( "mdr.btx" );
+    try {
+      removeTestDomain();
+    } finally {
+      deleteFile( "mdr.btb" );
+      deleteFile( "mdr.btd" );
+      deleteFile( "mdr.btx" );
+    }
   }
 
   private void deleteFile( String filename ) {
@@ -70,6 +78,13 @@ public class MQLQueryIT extends TestCase {
     if ( f.exists() ) {
       f.delete();
     }
+  }
+
+  private void removeTestDomain() throws CWMException {
+    if ( CWM.exists( TEST_DOMAIN ) ) {
+      CWM.getInstance( TEST_DOMAIN, false ).removeDomain();
+    }
+    cwm = null;
   }
 
   public String loadXmlFile( String filename ) {
@@ -82,9 +97,8 @@ public class MQLQueryIT extends TestCase {
   }
 
   public void loadOrdersModel() {
-    CWM cwm = null;
     try {
-      cwm = CWM.getInstance( "Orders", true ); //$NON-NLS-1$
+      cwm = CWM.getInstance( TEST_DOMAIN, true );
       assertNotNull( "CWM singleton instance is null", cwm );
       cwm.importFromXMI( getClass().getResourceAsStream( "/samples/orders.xmi" ) ); //$NON-NLS-1$
     } catch ( Exception e ) {
@@ -569,16 +583,18 @@ public class MQLQueryIT extends TestCase {
     quantityOrdered.setAggregationType( AggregationSettings.NONE );
     buyPrice.setAggregationType( AggregationSettings.NONE );
 
-    // This changes the expected result...
-    //
-    String formula = "SUM( [BT_ORDER_DETAILS.BC_ORDER_DETAILS_QUANTITYORDERED] * [BT_PRODUCTS.BC_PRODUCTS_BUYPRICE] )";
-    String sql = "SUM( BT_ORDER_DETAILS.QUANTITYORDERED  *  BT_PRODUCTS.BUYPRICE )";
+    try {
+      // This changes the expected result...
+      //
+      String formula = "SUM( [BT_ORDER_DETAILS.BC_ORDER_DETAILS_QUANTITYORDERED] * [BT_PRODUCTS.BC_PRODUCTS_BUYPRICE] )";
+      String sql = "SUM( BT_ORDER_DETAILS.QUANTITYORDERED  *  BT_PRODUCTS.BUYPRICE )";
 
-    handleFormula( ordersModel, "Hypersonic", formula, sql );
-
-    // Set it back to the way it was for further testing.
-    quantityOrdered.setAggregationType( qaBackup );
-    buyPrice.setAggregationType( paBackup );
+      handleFormula( ordersModel, "Hypersonic", formula, sql );
+    } finally {
+      // Set it back to the way it was for further testing.
+      quantityOrdered.setAggregationType( qaBackup );
+      buyPrice.setAggregationType( paBackup );
+    }
   }
 
   /**
@@ -598,16 +614,18 @@ public class MQLQueryIT extends TestCase {
     quantityOrdered.setAggregationType( AggregationSettings.SUM );
     buyPrice.setAggregationType( AggregationSettings.SUM );
 
-    // This changes the expected result...
-    //
-    String formula = "[BT_ORDER_DETAILS.BC_ORDER_DETAILS_QUANTITYORDERED] * [BT_PRODUCTS.BC_PRODUCTS_BUYPRICE]";
-    String sql = "SUM(BT_ORDER_DETAILS.QUANTITYORDERED)  *  SUM(BT_PRODUCTS.BUYPRICE)";
+    try {
+      // This changes the expected result...
+      //
+      String formula = "[BT_ORDER_DETAILS.BC_ORDER_DETAILS_QUANTITYORDERED] * [BT_PRODUCTS.BC_PRODUCTS_BUYPRICE]";
+      String sql = "SUM(BT_ORDER_DETAILS.QUANTITYORDERED)  *  SUM(BT_PRODUCTS.BUYPRICE)";
 
-    handleFormula( ordersModel, "Hypersonic", formula, sql );
-
-    // Set it back to the way it was for further testing.
-    quantityOrdered.setAggregationType( qaBackup );
-    buyPrice.setAggregationType( paBackup );
+      handleFormula( ordersModel, "Hypersonic", formula, sql );
+    } finally {
+      // Set it back to the way it was for further testing.
+      quantityOrdered.setAggregationType( qaBackup );
+      buyPrice.setAggregationType( paBackup );
+    }
   }
 
   public void testMQLQueryFactoryPentahoMetadataException() {

--- a/src/it/java/org/pentaho/pms/mql/dialect/SQLJoinIT.java
+++ b/src/it/java/org/pentaho/pms/mql/dialect/SQLJoinIT.java
@@ -167,8 +167,15 @@ public class SQLJoinIT {
     final LoggerContext context = LoggerContext.getContext(false);
     final Configuration config = context.getConfiguration();
     final LoggerConfig sqlJoinLogger = config.getLoggers().get( SQLJoin.class.getName() );
-    sqlJoinLogger.removeAppender( outputStreamName );
+    final Appender appender = config.getAppender( outputStreamName );
+    if ( sqlJoinLogger != null ) {
+      sqlJoinLogger.removeAppender( outputStreamName );
+    }
     config.removeLogger( SQLJoin.class.getName() );
+    if ( appender != null ) {
+      config.getAppenders().remove( outputStreamName );
+      appender.stop();
+    }
     context.updateLoggers();
   }
 

--- a/src/it/java/org/pentaho/pms/mql/dialect/SQLJoinIT.java
+++ b/src/it/java/org/pentaho/pms/mql/dialect/SQLJoinIT.java
@@ -149,6 +149,7 @@ public class SQLJoinIT {
   private void addAppender( final OutputStream outputStream, final String outputStreamName ) {
     final LoggerContext context = LoggerContext.getContext(false);
     final Configuration config = context.getConfiguration();
+    final LoggerConfig sqlJoinLogger = new LoggerConfig( SQLJoin.class.getName(), Level.DEBUG, false );
     final Appender appender =
       OutputStreamAppender.newBuilder()
         .setLayout( PatternLayout.createDefaultLayout() )
@@ -157,20 +158,18 @@ public class SQLJoinIT {
         .build();
     appender.start();
     config.addAppender( appender );
-    for ( final LoggerConfig loggerConfig : config.getLoggers().values() ) {
-        loggerConfig.addAppender( appender, Level.ALL, (Filter) null );
-    }
-    config.getRootLogger().addAppender( appender, Level.ALL, (Filter) null );
+    sqlJoinLogger.addAppender( appender, Level.ALL, (Filter) null );
+    config.addLogger( SQLJoin.class.getName(), sqlJoinLogger );
+    context.updateLoggers();
   }
 
   private void removeAppender( final String outputStreamName ) {
     final LoggerContext context = LoggerContext.getContext(false);
     final Configuration config = context.getConfiguration();
-    config.getAppender(outputStreamName);
-    for ( final LoggerConfig loggerConfig : config.getLoggers().values() ) {
-        loggerConfig.removeAppender(outputStreamName);
-    }
-    config.getRootLogger().removeAppender(outputStreamName);
+    final LoggerConfig sqlJoinLogger = config.getLoggers().get( SQLJoin.class.getName() );
+    sqlJoinLogger.removeAppender( outputStreamName );
+    config.removeLogger( SQLJoin.class.getName() );
+    context.updateLoggers();
   }
 
   private LogicalTable[] getTablesWithRelationships( RelationshipType relationship1, RelationshipType relationship2,

--- a/src/main/java/org/pentaho/metadata/util/SerializationService.java
+++ b/src/main/java/org/pentaho/metadata/util/SerializationService.java
@@ -40,12 +40,12 @@ public class SerializationService {
   public Domain deserializeDomain( String xml ) {
 
     try {
-      XStream xstream = createXStreamWithAllowedTypes(new DomDriver(), Domain.class );
+      XStream xstream = createXStreamForDomain( new DomDriver() );
       return (Domain) xstream.fromXML( xml );
     } catch ( StreamException e ) {
       // try to load ASCII. This addresses sample domains being mixed with customer created ones in
       // a different encoding.
-      XStream xstream = createXStreamWithAllowedTypes( new DomDriver("ISO-8859-1" ), Domain.class );
+      XStream xstream = createXStreamForDomain( new DomDriver( "ISO-8859-1" ) );
       return (Domain) xstream.fromXML( xml );
     }
   }
@@ -53,19 +53,24 @@ public class SerializationService {
   public Domain deserializeDomain( InputStream stream ) {
 
     try {
-      XStream xstream = createXStreamWithAllowedTypes( new DomDriver(), Domain.class );
+      XStream xstream = createXStreamForDomain( new DomDriver() );
       return (Domain) xstream.fromXML( stream );
     } catch ( StreamException e ) {
       // try to load ASCII. This addresses sample domains being mixed with customer created ones in
       // a different encoding.
-      XStream xstream = createXStreamWithAllowedTypes( new DomDriver("ISO-8859-1" ), Domain.class );
+      XStream xstream = createXStreamForDomain( new DomDriver( "ISO-8859-1" ) );
       return (Domain) xstream.fromXML( stream );
     }
   }
 
+  private static XStream createXStreamForDomain( AbstractXmlDriver driver ) {
+    XStream xstream = createXStreamWithAllowedTypes( driver, Domain.class );
+    xstream.allowTypesByWildcard( new String[] { "org.pentaho.metadata.model.**" } );
+    return xstream;
+  }
+
   public static XStream createXStreamWithAllowedTypes( AbstractXmlDriver driver, Class ... classes ) {
     XStream xstream = driver == null ? new XStream() : new XStream( driver );
-    xstream.allowTypesByWildcard( new String[] { "org.pentaho.metadata.model.**" } );
     if( classes != null ) {
       xstream.allowTypes( classes );
     }

--- a/src/main/java/org/pentaho/metadata/util/SerializationService.java
+++ b/src/main/java/org/pentaho/metadata/util/SerializationService.java
@@ -16,7 +16,7 @@ package org.pentaho.metadata.util;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import com.thoughtworks.xstream.io.xml.AbstractXmlDriver;
+import com.thoughtworks.xstream.io.HierarchicalStreamDriver;
 import org.pentaho.metadata.model.Domain;
 
 import com.thoughtworks.xstream.XStream;
@@ -63,13 +63,13 @@ public class SerializationService {
     }
   }
 
-  private static XStream createXStreamForDomain( AbstractXmlDriver driver ) {
+  private static XStream createXStreamForDomain( HierarchicalStreamDriver driver ) {
     XStream xstream = createXStreamWithAllowedTypes( driver, Domain.class );
     xstream.allowTypesByWildcard( new String[] { "org.pentaho.metadata.model.**" } );
     return xstream;
   }
 
-  public static XStream createXStreamWithAllowedTypes( AbstractXmlDriver driver, Class ... classes ) {
+  public static XStream createXStreamWithAllowedTypes( HierarchicalStreamDriver driver, Class ... classes ) {
     XStream xstream = driver == null ? new XStream() : new XStream( driver );
     if( classes != null ) {
       xstream.allowTypes( classes );

--- a/src/main/java/org/pentaho/metadata/util/SerializationService.java
+++ b/src/main/java/org/pentaho/metadata/util/SerializationService.java
@@ -65,9 +65,10 @@ public class SerializationService {
 
   public static XStream createXStreamWithAllowedTypes( AbstractXmlDriver driver, Class ... classes ) {
     XStream xstream = driver == null ? new XStream() : new XStream( driver );
-      if( classes != null ) {
-        xstream.allowTypes( classes );
-      }
+    xstream.allowTypesByWildcard( new String[] { "org.pentaho.metadata.model.**" } );
+    if( classes != null ) {
+      xstream.allowTypes( classes );
+    }
       return xstream;
   }
 


### PR DESCRIPTION
## Summary
- Allow the metadata XStream serializer to deserialize trusted model types.
- Capture the SQLJoin legacy-order debug marker with a dedicated DEBUG logger.
- Reset and clean up CWM domains owned by legacy integration-test fixtures.

## Validation
- `mvn --batch-mode verify -DrunITs -Dit.test=SQLModelGeneratorIT,ThinModelIT,MQLQueryIT,SQLJoinIT,SqlOpenFormulaIT`
  - 70 tests passed; 0 failures; 0 errors.