### PR TITLE
fix(metadata): stabilize metadata integration tests [BACKLOG-43752]

### DIFF
--- a/src/it/java/org/pentaho/metadata/SqlOpenFormulaIT.java
+++ b/src/it/java/org/pentaho/metadata/SqlOpenFormulaIT.java
@@ -105,6 +105,9 @@ public class SqlOpenFormulaIT {
 
   @AfterClass
   public static void deleteFiles() throws Exception {
+    if ( CWM.exists( "Orders" ) ) { //$NON-NLS-1$
+      CWM.getInstance( "Orders", false ).removeDomain(); //$NON-NLS-1$
+    }
     deleteFile( "mdr.btb" );
     deleteFile( "mdr.btd" );
     deleteFile( "mdr.btx" );

--- a/src/it/java/org/pentaho/metadata/ThinModelIT.java
+++ b/src/it/java/org/pentaho/metadata/ThinModelIT.java
@@ -13,6 +13,7 @@
 package org.pentaho.metadata;
 
 import org.junit.Assert;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.metadata.model.Category;
@@ -62,9 +63,24 @@ import static org.junit.Assert.fail;
 @SuppressWarnings( "deprecation" )
 public class ThinModelIT {
 
+  private static final String ORDERS_DOMAIN = "Orders";
+  private static final String STEEL_WHEELS_DOMAIN = "SteelWheels";
+
   @BeforeClass
   public static void initKettle() throws Exception {
     MetadataTestBase.initKettleEnvironment();
+  }
+
+  @After
+  public void removeLegacyDomains() throws Exception {
+    removeDomain( ORDERS_DOMAIN );
+    removeDomain( STEEL_WHEELS_DOMAIN );
+  }
+
+  private void removeDomain( String domainName ) throws Exception {
+    if ( CWM.exists( domainName ) ) {
+      CWM.getInstance( domainName, false ).removeDomain();
+    }
   }
 
   @Test

--- a/src/it/java/org/pentaho/pms/MQLQueryIT.java
+++ b/src/it/java/org/pentaho/pms/MQLQueryIT.java
@@ -25,6 +25,7 @@ import org.mockito.Mockito;
 import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.pms.core.CWM;
+import org.pentaho.pms.core.exception.CWMException;
 import org.pentaho.pms.core.exception.PentahoMetadataException;
 import org.pentaho.pms.factory.CwmSchemaFactory;
 import org.pentaho.pms.factory.CwmSchemaFactoryInterface;
@@ -46,22 +47,29 @@ import org.pentaho.pms.schema.concept.types.aggregation.AggregationSettings;
 @SuppressWarnings( { "deprecation", "nls" } )
 public class MQLQueryIT extends TestCase {
 
+  private static final String TEST_DOMAIN = "Orders";
+
   BusinessModel ordersModel = null;
 
   CwmSchemaFactory cwmSchemaFactory = null;
 
+  CWM cwm = null;
+
   public void setUp() throws Exception {
     MetadataTestBase.initKettleEnvironment();
-    if ( ordersModel == null || cwmSchemaFactory == null ) {
-      loadOrdersModel();
-    }
+    removeTestDomain();
+    loadOrdersModel();
   }
 
   @Override
   protected void tearDown() throws Exception {
-    deleteFile( "mdr.btb" );
-    deleteFile( "mdr.btd" );
-    deleteFile( "mdr.btx" );
+    try {
+      removeTestDomain();
+    } finally {
+      deleteFile( "mdr.btb" );
+      deleteFile( "mdr.btd" );
+      deleteFile( "mdr.btx" );
+    }
   }
 
   private void deleteFile( String filename ) {
@@ -69,6 +77,13 @@ public class MQLQueryIT extends TestCase {
     if ( f.exists() ) {
       f.delete();
     }
+  }
+
+  private void removeTestDomain() throws CWMException {
+    if ( CWM.exists( TEST_DOMAIN ) ) {
+      CWM.getInstance( TEST_DOMAIN, false ).removeDomain();
+    }
+    cwm = null;
   }
 
   public String loadXmlFile( String filename ) {
@@ -81,9 +96,8 @@ public class MQLQueryIT extends TestCase {
   }
 
   public void loadOrdersModel() {
-    CWM cwm = null;
     try {
-      cwm = CWM.getInstance( "Orders", true ); //$NON-NLS-1$
+      cwm = CWM.getInstance( TEST_DOMAIN, true );
       assertNotNull( "CWM singleton instance is null", cwm );
       cwm.importFromXMI( getClass().getResourceAsStream( "/samples/orders.xmi" ) ); //$NON-NLS-1$
     } catch ( Exception e ) {
@@ -568,16 +582,18 @@ public class MQLQueryIT extends TestCase {
     quantityOrdered.setAggregationType( AggregationSettings.NONE );
     buyPrice.setAggregationType( AggregationSettings.NONE );
 
-    // This changes the expected result...
-    //
-    String formula = "SUM( [BT_ORDER_DETAILS.BC_ORDER_DETAILS_QUANTITYORDERED] * [BT_PRODUCTS.BC_PRODUCTS_BUYPRICE] )";
-    String sql = "SUM( BT_ORDER_DETAILS.QUANTITYORDERED  *  BT_PRODUCTS.BUYPRICE )";
+    try {
+      // This changes the expected result...
+      //
+      String formula = "SUM( [BT_ORDER_DETAILS.BC_ORDER_DETAILS_QUANTITYORDERED] * [BT_PRODUCTS.BC_PRODUCTS_BUYPRICE] )";
+      String sql = "SUM( BT_ORDER_DETAILS.QUANTITYORDERED  *  BT_PRODUCTS.BUYPRICE )";
 
-    handleFormula( ordersModel, "Hypersonic", formula, sql );
-
-    // Set it back to the way it was for further testing.
-    quantityOrdered.setAggregationType( qaBackup );
-    buyPrice.setAggregationType( paBackup );
+      handleFormula( ordersModel, "Hypersonic", formula, sql );
+    } finally {
+      // Set it back to the way it was for further testing.
+      quantityOrdered.setAggregationType( qaBackup );
+      buyPrice.setAggregationType( paBackup );
+    }
   }
 
   /**
@@ -597,16 +613,18 @@ public class MQLQueryIT extends TestCase {
     quantityOrdered.setAggregationType( AggregationSettings.SUM );
     buyPrice.setAggregationType( AggregationSettings.SUM );
 
-    // This changes the expected result...
-    //
-    String formula = "[BT_ORDER_DETAILS.BC_ORDER_DETAILS_QUANTITYORDERED] * [BT_PRODUCTS.BC_PRODUCTS_BUYPRICE]";
-    String sql = "SUM(BT_ORDER_DETAILS.QUANTITYORDERED)  *  SUM(BT_PRODUCTS.BUYPRICE)";
+    try {
+      // This changes the expected result...
+      //
+      String formula = "[BT_ORDER_DETAILS.BC_ORDER_DETAILS_QUANTITYORDERED] * [BT_PRODUCTS.BC_PRODUCTS_BUYPRICE]";
+      String sql = "SUM(BT_ORDER_DETAILS.QUANTITYORDERED)  *  SUM(BT_PRODUCTS.BUYPRICE)";
 
-    handleFormula( ordersModel, "Hypersonic", formula, sql );
-
-    // Set it back to the way it was for further testing.
-    quantityOrdered.setAggregationType( qaBackup );
-    buyPrice.setAggregationType( paBackup );
+      handleFormula( ordersModel, "Hypersonic", formula, sql );
+    } finally {
+      // Set it back to the way it was for further testing.
+      quantityOrdered.setAggregationType( qaBackup );
+      buyPrice.setAggregationType( paBackup );
+    }
   }
 
   public void testMQLQueryFactoryPentahoMetadataException() {

--- a/src/it/java/org/pentaho/pms/mql/dialect/SQLJoinIT.java
+++ b/src/it/java/org/pentaho/pms/mql/dialect/SQLJoinIT.java
@@ -148,6 +148,7 @@ public class SQLJoinIT {
   private void addAppender( final OutputStream outputStream, final String outputStreamName ) {
     final LoggerContext context = LoggerContext.getContext(false);
     final Configuration config = context.getConfiguration();
+    final LoggerConfig sqlJoinLogger = new LoggerConfig( SQLJoin.class.getName(), Level.DEBUG, false );
     final Appender appender =
       OutputStreamAppender.newBuilder()
         .setLayout( PatternLayout.createDefaultLayout() )
@@ -156,20 +157,25 @@ public class SQLJoinIT {
         .build();
     appender.start();
     config.addAppender( appender );
-    for ( final LoggerConfig loggerConfig : config.getLoggers().values() ) {
-        loggerConfig.addAppender( appender, Level.ALL, (Filter) null );
-    }
-    config.getRootLogger().addAppender( appender, Level.ALL, (Filter) null );
+    sqlJoinLogger.addAppender( appender, Level.ALL, (Filter) null );
+    config.addLogger( SQLJoin.class.getName(), sqlJoinLogger );
+    context.updateLoggers();
   }
 
   private void removeAppender( final String outputStreamName ) {
     final LoggerContext context = LoggerContext.getContext(false);
     final Configuration config = context.getConfiguration();
-    config.getAppender(outputStreamName);
-    for ( final LoggerConfig loggerConfig : config.getLoggers().values() ) {
-        loggerConfig.removeAppender(outputStreamName);
+    final LoggerConfig sqlJoinLogger = config.getLoggers().get( SQLJoin.class.getName() );
+    final Appender appender = config.getAppender( outputStreamName );
+    if ( sqlJoinLogger != null ) {
+      sqlJoinLogger.removeAppender( outputStreamName );
     }
-    config.getRootLogger().removeAppender(outputStreamName);
+    config.removeLogger( SQLJoin.class.getName() );
+    if ( appender != null ) {
+      config.getAppenders().remove( outputStreamName );
+      appender.stop();
+    }
+    context.updateLoggers();
   }
 
   private LogicalTable[] getTablesWithRelationships( RelationshipType relationship1, RelationshipType relationship2,

--- a/src/main/java/org/pentaho/metadata/util/SerializationService.java
+++ b/src/main/java/org/pentaho/metadata/util/SerializationService.java
@@ -15,7 +15,7 @@ package org.pentaho.metadata.util;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import com.thoughtworks.xstream.io.xml.AbstractXmlDriver;
+import com.thoughtworks.xstream.io.HierarchicalStreamDriver;
 import org.pentaho.metadata.model.Domain;
 
 import com.thoughtworks.xstream.XStream;
@@ -39,12 +39,12 @@ public class SerializationService {
   public Domain deserializeDomain( String xml ) {
 
     try {
-      XStream xstream = createXStreamWithAllowedTypes(new DomDriver(), Domain.class );
+      XStream xstream = createXStreamForDomain( new DomDriver() );
       return (Domain) xstream.fromXML( xml );
     } catch ( StreamException e ) {
       // try to load ASCII. This addresses sample domains being mixed with customer created ones in
       // a different encoding.
-      XStream xstream = createXStreamWithAllowedTypes( new DomDriver("ISO-8859-1" ), Domain.class );
+      XStream xstream = createXStreamForDomain( new DomDriver( "ISO-8859-1" ) );
       return (Domain) xstream.fromXML( xml );
     }
   }
@@ -52,21 +52,27 @@ public class SerializationService {
   public Domain deserializeDomain( InputStream stream ) {
 
     try {
-      XStream xstream = createXStreamWithAllowedTypes( new DomDriver(), Domain.class );
+      XStream xstream = createXStreamForDomain( new DomDriver() );
       return (Domain) xstream.fromXML( stream );
     } catch ( StreamException e ) {
       // try to load ASCII. This addresses sample domains being mixed with customer created ones in
       // a different encoding.
-      XStream xstream = createXStreamWithAllowedTypes( new DomDriver("ISO-8859-1" ), Domain.class );
+      XStream xstream = createXStreamForDomain( new DomDriver( "ISO-8859-1" ) );
       return (Domain) xstream.fromXML( stream );
     }
   }
 
-  public static XStream createXStreamWithAllowedTypes( AbstractXmlDriver driver, Class ... classes ) {
+  private static XStream createXStreamForDomain( HierarchicalStreamDriver driver ) {
+    XStream xstream = createXStreamWithAllowedTypes( driver, Domain.class );
+    xstream.allowTypesByWildcard( new String[] { "org.pentaho.metadata.model.**" } );
+    return xstream;
+  }
+
+  public static XStream createXStreamWithAllowedTypes( HierarchicalStreamDriver driver, Class ... classes ) {
     XStream xstream = driver == null ? new XStream() : new XStream( driver );
-      if( classes != null ) {
-        xstream.allowTypes( classes );
-      }
+    if( classes != null ) {
+      xstream.allowTypes( classes );
+    }
       return xstream;
   }
 

--- a/src/main/java/org/pentaho/metadata/util/SerializationService.java
+++ b/src/main/java/org/pentaho/metadata/util/SerializationService.java
@@ -20,6 +20,7 @@ import org.pentaho.metadata.model.Domain;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.StreamException;
+import com.thoughtworks.xstream.io.xml.AbstractXmlDriver;
 import com.thoughtworks.xstream.io.xml.DomDriver;
 
 public class SerializationService {
@@ -73,7 +74,15 @@ public class SerializationService {
     if( classes != null ) {
       xstream.allowTypes( classes );
     }
-      return xstream;
+    return xstream;
+  }
+
+  /**
+   * @deprecated Use {@link #createXStreamWithAllowedTypes(HierarchicalStreamDriver, Class[])}.
+   */
+  @Deprecated
+  public static XStream createXStreamWithAllowedTypes( AbstractXmlDriver driver, Class ... classes ) {
+    return createXStreamWithAllowedTypes( (HierarchicalStreamDriver) driver, classes );
   }
 
 


### PR DESCRIPTION
## Summary
Backports pentaho/pentaho-metadata#261 and pentaho/pentaho-metadata#263 to the 11.0 line.

The patch isolates persistent CWM domains, restores aggregation settings in `finally` blocks, limits SQLJoin log capture to its test logger, and permits metadata model types during domain deserialization.

## Validation
```text
mvn --batch-mode -DrunITs compiler:compile build-helper:add-test-source@test-integration_add-source resources:copy-resources@test-integration_add-resources compiler:testCompile@test-integration_compile -Dit.test=SqlOpenFormulaIT,ThinModelIT,MQLQueryIT,SQLJoinIT failsafe:integration-test failsafe:verify
```
Failsafe XML: 66 tests, 0 failures, 0 errors, 0 skipped.

Backport base: `pentaho/11.0` at `3773f2aa2e182bceae87f04192e098c27e92d267`.
Commit: `dbdf5a55709f32917ce2a214593bf4a848b0c052`.