### PR TITLE
fix(metadata): restore XStream API compatibility [BACKLOG-43752]

### DIFF
--- a/src/main/java/org/pentaho/metadata/util/SerializationService.java
+++ b/src/main/java/org/pentaho/metadata/util/SerializationService.java
@@ -21,6 +21,7 @@ import org.pentaho.metadata.model.Domain;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.StreamException;
+import com.thoughtworks.xstream.io.xml.AbstractXmlDriver;
 import com.thoughtworks.xstream.io.xml.DomDriver;
 
 public class SerializationService {
@@ -74,7 +75,15 @@ public class SerializationService {
     if( classes != null ) {
       xstream.allowTypes( classes );
     }
-      return xstream;
+    return xstream;
+  }
+
+  /**
+   * @deprecated Use {@link #createXStreamWithAllowedTypes(HierarchicalStreamDriver, Class[])}.
+   */
+  @Deprecated
+  public static XStream createXStreamWithAllowedTypes( AbstractXmlDriver driver, Class ... classes ) {
+    return createXStreamWithAllowedTypes( (HierarchicalStreamDriver) driver, classes );
   }
 
 


### PR DESCRIPTION
## Summary
Restores the previous public `createXStreamWithAllowedTypes(AbstractXmlDriver, Class...)` descriptor as a deprecated overload delegating to the generalized `HierarchicalStreamDriver` implementation.

This prevents `NoSuchMethodError` for downstream applications compiled against the former public API, while retaining support for the generalized driver type. It also corrects the `return xstream` indentation.

Checked-out Pentaho repositories contain 22 Java occurrences of this helper, including data-access production callers. Existing source callers passing `null` continue to compile, but preserving the old descriptor protects independently compiled downstream binaries.

## Validation
```text
mvn --batch-mode compile
```
Build success. `javap` verifies both public descriptors:
```text
createXStreamWithAllowedTypes(HierarchicalStreamDriver, Class...)
createXStreamWithAllowedTypes(AbstractXmlDriver, Class...)
```

Base: `pentaho/master` at `6585ee99e55b4ff389aecc5072d1cc4512d4ea05`.
Commit: `21871c7593247168295269948c0d93bc28b79226`.